### PR TITLE
feat: initial keepassxc-cli

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,32 @@
+name: Auto Merge Dependabot
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    name: Auto Merge Dependabot PR
+    runs-on: ubuntu-24.04
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID_MERGE }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY_MERGE }}
+      - name: Enable Pull Request Automerge
+        run: gh pr merge --squash --auto "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Auto approve
+        run: gh pr review --approve "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,41 @@
+name: Auto Release
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  auto-release:
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'pip')
+
+    name: Auto Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get Version
+        id: get-version
+        run: |
+          LATEST_TAG=$(curl -s "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r '.name')
+          # Strip leading 'v' if present
+          VERSION="${LATEST_TAG#v}"
+          # Parse semver components
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          # Bump minor, reset patch
+          MINOR=$((MINOR + 1))
+          PATCH=0
+          echo "version=v${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
+      - uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID_MERGE }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY_MERGE }}
+      - name: Create Release
+        run: gh release create ${{ steps.get-version.outputs.version }} --generate-notes
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,0 +1,59 @@
+name: Python Lint and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+
+permissions:
+  contents: read
+
+jobs:
+  Test:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+          pip install -e ".[dev]"
+      - name: Test with pytest
+        run: |
+          pytest --cov=keepassxc_cli --cov-report=term-missing
+      - name: Lint with ruff
+        env:
+          PY_VER: ${{ matrix.python-version }}
+        run: |
+          PY_VER=$(echo py${PY_VER} | tr -d '.')
+          ruff check --output-format=github --ignore=E501 --exclude=__init__.py --target-version=${PY_VER} ./keepassxc_cli
+
+  Check-Test:
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    needs:
+      - Test
+    steps:
+      - run: |
+          result="${{ needs.Test.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,79 @@
+name: Build & Upload Python Package
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  Setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Get Version
+      id: set-version
+      env:
+        VERSION: ${{ github.ref_name }}
+      run: |
+        if grep -c -E '^v[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}$' <<< ${VERSION}; then
+          VERSION=$(sed 's/^.\{1\}//g' <<< ${VERSION})
+        else
+          echo "This branch shouldn't be build: ${VERSION}"
+          exit 1
+        fi
+        echo "version=$(echo ${VERSION})" >> $GITHUB_OUTPUT
+
+  Deploy:
+    runs-on: ubuntu-24.04
+    needs: Setup
+    environment:
+      name: pypi
+      url: https://pypi.org/p/keepassxc-cli/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.Setup.outputs.version }}
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@v1.14.0
+
+  Notify-Homebrew:
+    runs-on: ubuntu-24.04
+    needs: [Setup, Deploy]
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID_MERGE }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY_MERGE }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+      - name: Trigger Homebrew formula update
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh api repos/${{ github.repository_owner }}/homebrew-tap/dispatches \
+            -f event_type=update-keepassxc-cli \
+            -f "client_payload[version]=${{ needs.Setup.outputs.version }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md — keepassxc-cli
+
+This document provides context for AI assistants working on this project.
+
+## Project Purpose
+
+`keepassxc-cli` is a Python command-line tool that communicates with a running KeePassXC instance using the KeePassXC Browser Extension protocol (native messaging over a Unix socket). It enables terminal users to interact with KeePassXC — listing, searching, adding, editing, and deleting entries — while leveraging KeePassXC's biometric (TouchID/fingerprint) unlock support.
+
+## Package Structure
+
+```
+keepassxc_cli/
+├── __init__.py          # empty (just from __future__ import annotations)
+├── __main__.py          # CLI entry point; argument parsing; dispatches to commands
+├── config.py            # CliConfig dataclass; save/load ~/.keepassxc/cli.json
+├── output.py            # Output formatting: table, json, tsv
+└── commands/
+    ├── __init__.py      # empty
+    ├── setup.py         # associate with KeePassXC
+    ├── status.py        # show connection/association status
+    ├── show.py          # show entries by URL
+    ├── search.py        # search all entries
+    ├── ls.py            # list entries or groups
+    ├── add.py           # add new entry
+    ├── edit.py          # edit existing entry by UUID
+    ├── rm.py            # delete entry by UUID
+    ├── totp.py          # get TOTP code
+    ├── clip.py          # copy field to clipboard
+    ├── generate.py      # generate password
+    ├── lock.py          # lock database
+    └── mkdir.py         # create group
+
+tests/
+├── conftest.py          # fixtures: mock_entry, mock_group, mock_browser_config, mock_client
+├── test_config.py       # CliConfig unit tests
+├── test_output.py       # output formatting tests
+└── test_commands.py     # command run() function tests with mocked BrowserClient
+```
+
+## Dependency: keepassxc-browser-api
+
+This package depends on `keepassxc-browser-api` (local package at `../mietzen-keepassxc-browser-api/`), which provides:
+
+- `BrowserClient` — the main client that communicates with KeePassXC
+- `BrowserConfig` — configuration dataclass (associations, keys)
+- `Entry`, `Group` — data models
+- Exceptions: `KeePassXCError`, `AssociationError`, `NotAssociatedError`, `DatabaseLockedError`, `ProtocolError`, `ConnectionError`
+
+Import path: `from keepassxc_browser_api import BrowserClient, BrowserConfig, Entry, Group`
+
+## Command Module Convention
+
+Every command module (`keepassxc_cli/commands/*.py`) must implement:
+
+```python
+def add_parser(subparsers) -> None:
+    p = subparsers.add_parser("name", help="...")
+    # add arguments
+    p.set_defaults(func=run)
+
+def run(client, args, cli_config, browser_config, browser_config_path, *, fmt="table") -> int:
+    # returns 0 on success, non-zero on failure
+    ...
+```
+
+The `run()` function signature is always:
+```python
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+```
+
+## How to Build, Test, and Lint
+
+```bash
+# Create venv and install
+python3 -m venv .venv
+source .venv/bin/activate
+pip install ../mietzen-keepassxc-browser-api/   # local dependency
+pip install -e ".[dev]"
+
+# Run tests
+pytest --tb=short -q
+pytest --cov=keepassxc_cli --cov-report=term-missing
+
+# Lint
+ruff check --ignore=E501 --exclude=__init__.py ./keepassxc_cli
+```
+
+## Key Conventions
+
+- **`from __future__ import annotations`** must be the first line of every `.py` source file.
+- **Ruff**: `ruff check --ignore=E501 --exclude=__init__.py ./keepassxc_cli`
+- **No async code**: Everything is synchronous. No threads in the CLI.
+- **Output**: Use `print()` for normal output, `sys.stderr` for errors.
+- **Exit codes**: `run()` functions return `int` (0 = success, 1 = failure).
+- **Config permissions**: Config files are written with `0o600` (owner read/write only).
+- **Venv**: Always use `.venv` for development.
+- **Python ≥ 3.10** required.
+
+## Config Files
+
+| File | Purpose |
+|------|---------|
+| `~/.keepassxc/cli.json` | CLI preferences (default format, custom browser-api config path). Only non-default values stored. |
+| `~/.keepassxc/browser-api.json` | Shared with keepassxc-browser-api. Contains association keys. Written by `setup` command. |
+
+## Output Formats
+
+Three formats are supported everywhere: `table` (default), `json`, `tsv`. The `--format` global flag or `default_format` in `cli.json` controls the default.

--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ keepassxc-cli status
 #### `ls` — List entries or groups
 
 ```bash
-keepassxc-cli ls                # list all entries
+keepassxc-cli ls                # list all entries (includes UUID column)
 keepassxc-cli ls --groups       # list groups (tree view)
 keepassxc-cli ls --format json  # output as JSON
 ```
+
+UUIDs shown in the output are needed for `edit`, `rm`, `totp`, and `clip --field totp`.
 
 #### `search` — Search entries
 
@@ -104,6 +106,8 @@ keepassxc-cli add --url https://example.com --username user --password mypass
 ```
 
 #### `edit` — Edit an entry
+
+> **Finding a UUID**: Use `keepassxc-cli ls` or `keepassxc-cli search <query>` to list entries with their UUIDs.
 
 ```bash
 keepassxc-cli edit <uuid> --username newuser

--- a/README.md
+++ b/README.md
@@ -1,0 +1,207 @@
+# keepassxc-cli
+
+A command-line interface for [KeePassXC](https://keepassxc.org/) that communicates via the browser extension protocol, supporting biometric (TouchID/fingerprint) unlock on supported platforms.
+
+## What it is
+
+`keepassxc-cli` talks to a running KeePassXC instance using the same native messaging protocol used by the KeePassXC Browser extension. This means:
+
+- **Biometric unlock**: On macOS with TouchID (or similar) configured in KeePassXC, you can authenticate via fingerprint rather than typing your master password.
+- **No master password in shell history**: Authentication happens through KeePassXC's GUI, not the terminal.
+- **Full CRUD**: List, search, add, edit, delete entries and groups.
+- **TOTP**: Retrieve time-based one-time passwords.
+- **Clipboard**: Copy credentials directly to the clipboard.
+
+## Prerequisites
+
+1. **KeePassXC** ≥ 2.7 with the **Browser Integration** feature enabled:
+   - Open KeePassXC → Tools → Settings → Browser Integration
+   - Enable "Enable browser integration"
+2. A KeePassXC database must be open (or KeePassXC must be running with auto-open configured).
+3. Python ≥ 3.10
+
+## Installation
+
+```bash
+pipx install keepassxc-cli
+```
+
+Or with pip:
+
+```bash
+pip install keepassxc-cli
+```
+
+## Setup
+
+Before using `keepassxc-cli`, associate it with your KeePassXC instance:
+
+```bash
+keepassxc-cli setup
+```
+
+This performs a key exchange with KeePassXC (you will be prompted to allow the association in the KeePassXC GUI). The association is saved to `~/.keepassxc/browser-api.json`.
+
+## Usage
+
+### Global options
+
+```
+keepassxc-cli [--config PATH] [--browser-api-config PATH] [--format {table,json,tsv}] [-v] COMMAND
+```
+
+| Option | Description |
+|--------|-------------|
+| `--config` | Path to CLI config file (default: `~/.keepassxc/cli.json`) |
+| `--browser-api-config` | Path to browser API config file (default: `~/.keepassxc/browser-api.json`) |
+| `--format` | Output format: `table` (default), `json`, or `tsv` |
+| `-v, --verbose` | Enable verbose/debug logging |
+
+### Commands
+
+#### `setup` — Associate with KeePassXC
+
+```bash
+keepassxc-cli setup
+```
+
+#### `status` — Connection and association status
+
+```bash
+keepassxc-cli status
+```
+
+#### `ls` — List entries or groups
+
+```bash
+keepassxc-cli ls                # list all entries
+keepassxc-cli ls --groups       # list groups (tree view)
+keepassxc-cli ls --format json  # output as JSON
+```
+
+#### `search` — Search entries
+
+```bash
+keepassxc-cli search github
+keepassxc-cli search "my bank" --show-password
+```
+
+Searches case-insensitively across title, username, and URL fields.
+
+#### `show` — Show entries for a URL
+
+```bash
+keepassxc-cli show https://github.com
+keepassxc-cli show https://github.com -p   # reveal password
+```
+
+#### `add` — Add a new entry
+
+```bash
+keepassxc-cli add --url https://example.com --username user@example.com --title "Example"
+# Password will be prompted securely if --password is not given
+keepassxc-cli add --url https://example.com --username user --password mypass
+```
+
+#### `edit` — Edit an entry
+
+```bash
+keepassxc-cli edit <uuid> --username newuser
+keepassxc-cli edit <uuid> --password newpass --title "New Title"
+```
+
+#### `rm` — Delete an entry
+
+```bash
+keepassxc-cli rm <uuid>          # prompts for confirmation
+keepassxc-cli rm <uuid> --yes    # skip confirmation
+```
+
+#### `totp` — Get TOTP code
+
+```bash
+keepassxc-cli totp <uuid>
+```
+
+#### `clip` — Copy to clipboard
+
+```bash
+keepassxc-cli clip https://github.com              # copies password
+keepassxc-cli clip https://github.com --field username
+keepassxc-cli clip https://github.com --field totp
+```
+
+#### `generate` — Generate a password
+
+```bash
+keepassxc-cli generate
+keepassxc-cli generate --length 32 --symbols
+keepassxc-cli generate --no-numbers --no-uppercase
+keepassxc-cli generate --clip    # copy to clipboard instead of printing
+```
+
+#### `lock` — Lock the database
+
+```bash
+keepassxc-cli lock
+```
+
+#### `mkdir` — Create a group
+
+```bash
+keepassxc-cli mkdir "Work"
+keepassxc-cli mkdir "Projects" --parent-uuid <parent-group-uuid>
+```
+
+## Configuration
+
+### CLI config (`~/.keepassxc/cli.json`)
+
+Only non-default values are stored. Available options:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `browser_api_config_path` | `~/.keepassxc/browser-api.json` | Path to the browser API config |
+| `default_format` | `table` | Default output format (`table`, `json`, `tsv`) |
+
+Example `~/.keepassxc/cli.json`:
+```json
+{
+  "default_format": "json"
+}
+```
+
+### Browser API config (`~/.keepassxc/browser-api.json`)
+
+Shared with `keepassxc-browser-api`. Contains the association keys created during `keepassxc-cli setup`. This file is automatically created and updated by the `setup` command.
+
+Both config files are stored with `0o600` permissions (owner read/write only).
+
+## Development
+
+```bash
+git clone https://github.com/mietzen/keepassxc-cli
+cd keepassxc-cli
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install local keepassxc-browser-api dependency first
+pip install ../mietzen-keepassxc-browser-api/
+
+# Install in editable mode with dev dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest --tb=short -q
+
+# Run linter
+ruff check --ignore=E501 --exclude=__init__.py ./keepassxc_cli
+```
+
+## Known Limitations
+
+- Requires KeePassXC to be **running** and the database to be **open** (or biometric auto-unlock configured).
+- The `clip` and `generate --clip` commands require `pyperclip` and a working clipboard (e.g., `xclip`/`xsel` on Linux, built-in on macOS/Windows).
+- The browser integration protocol does not support moving entries between groups directly.
+- Entry URLs in the database are stored as `KPH: url` string fields; entries without a URL field may not appear in `show` results.

--- a/keepassxc_cli/__init__.py
+++ b/keepassxc_cli/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/keepassxc_cli/__main__.py
+++ b/keepassxc_cli/__main__.py
@@ -1,0 +1,76 @@
+"""CLI entry point for keepassxc-cli."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+from keepassxc_browser_api.exceptions import KeePassXCError, ConnectionError
+
+from .config import CliConfig, DEFAULT_CLI_CONFIG_PATH
+from .commands import setup, status, show, search, ls, add, edit, rm, totp, clip, generate, lock, mkdir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="keepassxc-cli",
+        description="CLI for KeePassXC using the browser extension protocol with biometric unlock",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CLI_CONFIG_PATH),
+        help="Path to CLI config file (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--browser-api-config",
+        default=None,
+        help="Path to browser API config file",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "tsv"],
+        default=None,
+        dest="fmt",
+        help="Output format (default: table)",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+    subparsers.required = True
+
+    setup.add_parser(subparsers)
+    status.add_parser(subparsers)
+    show.add_parser(subparsers)
+    search.add_parser(subparsers)
+    ls.add_parser(subparsers)
+    add.add_parser(subparsers)
+    edit.add_parser(subparsers)
+    rm.add_parser(subparsers)
+    totp.add_parser(subparsers)
+    clip.add_parser(subparsers)
+    generate.add_parser(subparsers)
+    lock.add_parser(subparsers)
+    mkdir.add_parser(subparsers)
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    cli_config_path = Path(args.config)
+    cli_config = CliConfig.load(cli_config_path)
+
+    browser_api_config_path = Path(args.browser_api_config or cli_config.browser_api_config_path)
+    browser_config = BrowserConfig.load(browser_api_config_path)
+
+    fmt = args.fmt or cli_config.default_format
+
+    client = BrowserClient(browser_config)
+    try:
+        rc = args.func(client, args, cli_config, browser_config, browser_api_config_path, fmt=fmt)
+    except (KeePassXCError, ConnectionError, OSError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        rc = 1
+    sys.exit(rc)

--- a/keepassxc_cli/__main__.py
+++ b/keepassxc_cli/__main__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from pathlib import Path
@@ -70,7 +71,7 @@ def main() -> None:
     client = BrowserClient(browser_config)
     try:
         rc = args.func(client, args, cli_config, browser_config, browser_api_config_path, fmt=fmt)
-    except (KeePassXCError, ConnectionError, OSError) as e:
+    except (KeePassXCError, ConnectionError, OSError, json.JSONDecodeError) as e:
         print(f"Error: {e}", file=sys.stderr)
         rc = 1
     sys.exit(rc)

--- a/keepassxc_cli/commands/__init__.py
+++ b/keepassxc_cli/commands/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/keepassxc_cli/commands/add.py
+++ b/keepassxc_cli/commands/add.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("add", help="Add a new entry")
+    p.add_argument("--url", required=True, help="Entry URL")
+    p.add_argument("--username", required=True, help="Username")
+    p.add_argument("--password", default=None, help="Password (prompted if omitted)")
+    p.add_argument("--title", default="", help="Entry title")
+    p.add_argument("--group-uuid", default="", help="Target group UUID")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    password = args.password
+    if password is None:
+        password = getpass.getpass("Password: ")
+
+    success = client.set_login(
+        url=args.url,
+        username=args.username,
+        password=password,
+        title=args.title,
+        group_uuid=args.group_uuid,
+    )
+    if success:
+        print("Entry added successfully.")
+        return 0
+    else:
+        print("Failed to add entry.", file=sys.stderr)
+        return 1

--- a/keepassxc_cli/commands/clip.py
+++ b/keepassxc_cli/commands/clip.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("clip", help="Copy a field to clipboard")
+    p.add_argument("url", help="URL to look up")
+    p.add_argument(
+        "--field",
+        choices=["password", "username", "totp"],
+        default="password",
+        help="Field to copy (default: password)",
+    )
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    try:
+        import pyperclip
+    except ImportError:
+        print("Error: pyperclip is required for clipboard support. Install it with: pip install pyperclip", file=sys.stderr)
+        return 1
+
+    entries = client.get_logins(args.url)
+    if not entries:
+        print(f"No entries found for: {args.url}", file=sys.stderr)
+        return 1
+
+    entry = entries[0]
+
+    if args.field == "password":
+        value = entry.password
+    elif args.field == "username":
+        value = entry.login
+    elif args.field == "totp":
+        value = client.get_totp(entry.uuid)
+        if value is None:
+            print(f"No TOTP for entry: {entry.uuid}", file=sys.stderr)
+            return 1
+    else:
+        print(f"Unknown field: {args.field}", file=sys.stderr)
+        return 1
+
+    pyperclip.copy(value)
+    print(f"Copied {args.field} to clipboard.")
+    return 0

--- a/keepassxc_cli/commands/edit.py
+++ b/keepassxc_cli/commands/edit.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("edit", help="Edit an existing entry by UUID")
+    p.add_argument("uuid", help="UUID of the entry to edit")
+    p.add_argument("--url", default=None, help="New URL")
+    p.add_argument("--username", default=None, help="New username")
+    p.add_argument("--password", default=None, help="New password")
+    p.add_argument("--title", default=None, help="New title")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    all_entries = client.get_database_entries()
+    entry = next((e for e in all_entries if e.uuid == args.uuid), None)
+    if entry is None:
+        print(f"Entry not found: {args.uuid}", file=sys.stderr)
+        return 1
+
+    # Determine the URL to use for set_login (required by the API)
+    url = args.url or next(
+        (sf.get("KPH: url", "") for sf in entry.string_fields if "KPH: url" in sf),
+        "",
+    )
+
+    success = client.set_login(
+        url=url,
+        username=args.username if args.username is not None else entry.login,
+        password=args.password if args.password is not None else entry.password,
+        title=args.title if args.title is not None else entry.name,
+        uuid=entry.uuid,
+        group_uuid=entry.group_uuid,
+    )
+    if success:
+        print("Entry updated successfully.")
+        return 0
+    else:
+        print("Failed to update entry.", file=sys.stderr)
+        return 1

--- a/keepassxc_cli/commands/generate.py
+++ b/keepassxc_cli/commands/generate.py
@@ -11,13 +11,10 @@ from keepassxc_cli.output import print_password
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("generate", help="Generate a password")
-    p.add_argument("--length", type=int, default=20, help="Password length (default: 20)")
-    p.add_argument("--no-numbers", action="store_true", help="Exclude numbers")
-    p.add_argument("--no-lowercase", action="store_true", help="Exclude lowercase letters")
-    p.add_argument("--no-uppercase", action="store_true", help="Exclude uppercase letters")
-    p.add_argument("--symbols", action="store_true", help="Include symbols")
-    p.add_argument("--special", action="store_true", help="Include special characters")
+    p = subparsers.add_parser(
+        "generate",
+        help="Generate a password using KeePassXC's configured password profile",
+    )
     p.add_argument("--clip", action="store_true", help="Copy to clipboard instead of printing")
     p.set_defaults(func=run)
 
@@ -31,14 +28,7 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    password = client.generate_password(
-        length=args.length,
-        numbers=not args.no_numbers,
-        lowercase=not args.no_lowercase,
-        uppercase=not args.no_uppercase,
-        symbols=args.symbols,
-        special=args.special,
-    )
+    password = client.generate_password()
     if password is None:
         print("Failed to generate password.", file=sys.stderr)
         return 1

--- a/keepassxc_cli/commands/generate.py
+++ b/keepassxc_cli/commands/generate.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_password
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("generate", help="Generate a password")
+    p.add_argument("--length", type=int, default=20, help="Password length (default: 20)")
+    p.add_argument("--no-numbers", action="store_true", help="Exclude numbers")
+    p.add_argument("--no-lowercase", action="store_true", help="Exclude lowercase letters")
+    p.add_argument("--no-uppercase", action="store_true", help="Exclude uppercase letters")
+    p.add_argument("--symbols", action="store_true", help="Include symbols")
+    p.add_argument("--special", action="store_true", help="Include special characters")
+    p.add_argument("--clip", action="store_true", help="Copy to clipboard instead of printing")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    password = client.generate_password(
+        length=args.length,
+        numbers=not args.no_numbers,
+        lowercase=not args.no_lowercase,
+        uppercase=not args.no_uppercase,
+        symbols=args.symbols,
+        special=args.special,
+    )
+    if password is None:
+        print("Failed to generate password.", file=sys.stderr)
+        return 1
+
+    if args.clip:
+        try:
+            import pyperclip
+            pyperclip.copy(password)
+            print("Password copied to clipboard.")
+        except ImportError:
+            print("Error: pyperclip is required for clipboard support. Install it with: pip install pyperclip", file=sys.stderr)
+            return 1
+    else:
+        print_password(password, fmt)
+
+    return 0

--- a/keepassxc_cli/commands/lock.py
+++ b/keepassxc_cli/commands/lock.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("lock", help="Lock the KeePassXC database")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    success = client.lock_database()
+    if success:
+        print("Database locked.")
+        return 0
+    else:
+        print("Failed to lock database.", file=sys.stderr)
+        return 1

--- a/keepassxc_cli/commands/ls.py
+++ b/keepassxc_cli/commands/ls.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_entries, print_groups
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("ls", help="List database entries or groups")
+    p.add_argument("--groups", action="store_true", help="List groups instead of entries")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    if args.groups:
+        groups = client.get_database_groups()
+        print_groups(groups, fmt)
+    else:
+        entries = client.get_database_entries()
+        print_entries(entries, fmt)
+    return 0

--- a/keepassxc_cli/commands/mkdir.py
+++ b/keepassxc_cli/commands/mkdir.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("mkdir", help="Create a new group")
+    p.add_argument("name", help="Group name")
+    p.add_argument("--parent-uuid", default="", help="Parent group UUID")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    group = client.create_group(args.name, parent_group_uuid=args.parent_uuid)
+    if group is None:
+        print("Failed to create group.", file=sys.stderr)
+        return 1
+    print(f"Group created: {group.name} [{group.uuid}]")
+    return 0

--- a/keepassxc_cli/commands/rm.py
+++ b/keepassxc_cli/commands/rm.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("rm", help="Delete an entry by UUID")
+    p.add_argument("uuid", help="UUID of the entry to delete")
+    p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    if not args.yes:
+        answer = input(f"Delete entry {args.uuid}? [y/N] ").strip().lower()
+        if answer != "y":
+            print("Aborted.")
+            return 1
+
+    success = client.delete_entry(args.uuid)
+    if success:
+        print("Entry deleted.")
+        return 0
+    else:
+        print("Failed to delete entry.", file=sys.stderr)
+        return 1

--- a/keepassxc_cli/commands/search.py
+++ b/keepassxc_cli/commands/search.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_entries
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("search", help="Search all database entries")
+    p.add_argument("query", help="Search query (case-insensitive match on title, username, or URL)")
+    p.add_argument("-p", "--show-password", action="store_true", help="Reveal password")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    query = args.query.lower()
+    all_entries = client.get_database_entries()
+    matches = [
+        e for e in all_entries
+        if query in e.name.lower()
+        or query in e.login.lower()
+        or any(query in v.lower() for sf in e.string_fields for v in sf.values())
+    ]
+    if not matches:
+        print(f"No entries found matching: {args.query}", file=sys.stderr)
+        return 1
+    print_entries(matches, fmt, show_password=args.show_password)
+    return 0

--- a/keepassxc_cli/commands/search.py
+++ b/keepassxc_cli/commands/search.py
@@ -32,7 +32,7 @@ def run(
         e for e in all_entries
         if query in e.name.lower()
         or query in e.login.lower()
-        or any(query in v.lower() for sf in e.string_fields for v in sf.values())
+        or any(query in v.lower() for sf in e.string_fields for v in sf.values() if v is not None)
     ]
     if not matches:
         print(f"No entries found matching: {args.query}", file=sys.stderr)

--- a/keepassxc_cli/commands/setup.py
+++ b/keepassxc_cli/commands/setup.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("setup", help="Associate with KeePassXC (key exchange)")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    success = client.setup()
+    if success:
+        browser_config.save(browser_config_path)
+        print("Successfully associated with KeePassXC.")
+        return 0
+    else:
+        print("Failed to associate with KeePassXC.", file=sys.stderr)
+        return 1

--- a/keepassxc_cli/commands/show.py
+++ b/keepassxc_cli/commands/show.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_entry_detail
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("show", help="Show entries matching a URL")
+    p.add_argument("url", help="URL or search string")
+    p.add_argument("-p", "--show-password", action="store_true", help="Reveal password")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    entries = client.get_logins(args.url)
+    if not entries:
+        print(f"No entries found for: {args.url}", file=sys.stderr)
+        return 1
+    for entry in entries:
+        print_entry_detail(entry, fmt, show_password=args.show_password)
+        if fmt == "table" and len(entries) > 1:
+            print()
+    return 0

--- a/keepassxc_cli/commands/status.py
+++ b/keepassxc_cli/commands/status.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+from keepassxc_browser_api.exceptions import KeePassXCError
+
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_status
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("status", help="Show KeePassXC connection and association status")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    info: dict = {}
+
+    connected = client.connect()
+    info["Connected"] = "yes" if connected else "no"
+
+    if not connected:
+        print_status(info, fmt)
+        return 1
+
+    associated = False
+    if browser_config.associations:
+        try:
+            association = next(iter(browser_config.associations.values()))
+            associated = client.test_associate(association)
+        except KeePassXCError:
+            associated = False
+
+    info["Associated"] = "yes" if associated else "no"
+    info["Unlock timeout"] = str(browser_config.unlock_timeout)
+
+    client.disconnect()
+    print_status(info, fmt)
+    return 0

--- a/keepassxc_cli/commands/totp.py
+++ b/keepassxc_cli/commands/totp.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_totp
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("totp", help="Get TOTP code for an entry")
+    p.add_argument("uuid", help="UUID of the entry")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    totp = client.get_totp(args.uuid)
+    if totp is None:
+        print(f"No TOTP for entry: {args.uuid}", file=sys.stderr)
+        return 1
+    print_totp(totp, fmt)
+    return 0

--- a/keepassxc_cli/config.py
+++ b/keepassxc_cli/config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_BROWSER_API_CONFIG_PATH = str(Path.home() / ".keepassxc" / "browser-api.json")
+DEFAULT_CLI_CONFIG_PATH = Path.home() / ".keepassxc" / "cli.json"
+
+
+@dataclass
+class CliConfig:
+    browser_api_config_path: str = field(default_factory=lambda: DEFAULT_BROWSER_API_CONFIG_PATH)
+    default_format: str = "table"
+
+    def to_dict(self) -> dict:
+        d: dict = {}
+        if self.browser_api_config_path != DEFAULT_BROWSER_API_CONFIG_PATH:
+            d["browser_api_config_path"] = self.browser_api_config_path
+        if self.default_format != "table":
+            d["default_format"] = self.default_format
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CliConfig:
+        return cls(
+            browser_api_config_path=d.get("browser_api_config_path", DEFAULT_BROWSER_API_CONFIG_PATH),
+            default_format=d.get("default_format", "table"),
+        )
+
+    def save(self, path: Path | str) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = json.dumps(self.to_dict(), indent=2)
+        # Write with restricted permissions (0o600)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, data.encode())
+        finally:
+            os.close(fd)
+
+    @classmethod
+    def load(cls, path: Path | str) -> CliConfig:
+        path = Path(path)
+        if not path.exists():
+            return cls()
+        with open(path) as f:
+            d = json.load(f)
+        return cls.from_dict(d)

--- a/keepassxc_cli/output.py
+++ b/keepassxc_cli/output.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+
+from keepassxc_browser_api import Entry, Group
+
+
+def _truncate(s: str, n: int) -> str:
+    if len(s) > n:
+        return s[: n - 1] + "…"
+    return s
+
+
+def _table_row(cols: list[str], widths: list[int]) -> str:
+    return "| " + " | ".join(v.ljust(w) for v, w in zip(cols, widths)) + " |"
+
+
+def _table_sep(widths: list[int]) -> str:
+    return "+-" + "-+-".join("-" * w for w in widths) + "-+"
+
+
+def _print_table(headers: list[str], rows: list[list[str]]) -> None:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+    sep = _table_sep(widths)
+    print(sep)
+    print(_table_row(headers, widths))
+    print(sep)
+    for row in rows:
+        print(_table_row(row, widths))
+    print(sep)
+
+
+def print_entries(entries: list[Entry], fmt: str = "table", show_password: bool = False) -> None:
+    if fmt == "json":
+        data = [
+            {
+                "uuid": e.uuid,
+                "name": e.name,
+                "login": e.login,
+                "password": e.password if show_password else "***",
+                "url": next((sf.get("KPH: url", "") for sf in e.string_fields if "KPH: url" in sf), ""),
+                "group": e.group,
+            }
+            for e in entries
+        ]
+        print(json.dumps(data, indent=2))
+        return
+
+    if fmt == "tsv":
+        headers = ["UUID", "Title", "Username", "URL", "Group"]
+        print("\t".join(headers))
+        for e in entries:
+            url = next((sf.get("KPH: url", "") for sf in e.string_fields if "KPH: url" in sf), "")
+            print("\t".join([e.uuid, e.name, e.login, url, e.group]))
+        return
+
+    # table
+    headers = ["UUID", "Title", "Username", "URL", "Group"]
+    rows = []
+    for e in entries:
+        url = next((sf.get("KPH: url", "") for sf in e.string_fields if "KPH: url" in sf), "")
+        rows.append([_truncate(e.uuid, 9), e.name, e.login, url, e.group])
+    _print_table(headers, rows)
+
+
+def _print_group_tree(group: Group, indent: int = 0) -> None:
+    prefix = "  " * indent
+    print(f"{prefix}{group.name}  [{_truncate(group.uuid, 9)}]")
+    for child in group.children:
+        _print_group_tree(child, indent + 1)
+
+
+def print_groups(groups: list[Group], fmt: str = "table") -> None:
+    if fmt == "json":
+        def _g2d(g: Group) -> dict:
+            return {"uuid": g.uuid, "name": g.name, "children": [_g2d(c) for c in g.children]}
+        print(json.dumps([_g2d(g) for g in groups], indent=2))
+        return
+
+    if fmt == "tsv":
+        print("UUID\tName")
+        for g in groups:
+            for flat in g.flat_list():
+                print(f"{flat.uuid}\t{flat.name}")
+        return
+
+    for g in groups:
+        _print_group_tree(g)
+
+
+def print_entry_detail(entry: Entry, fmt: str = "table", show_password: bool = False) -> None:
+    password = entry.password if show_password else "***"
+    if fmt == "json":
+        data = {
+            "uuid": entry.uuid,
+            "name": entry.name,
+            "login": entry.login,
+            "password": password,
+            "totp": entry.totp,
+            "group": entry.group,
+            "group_uuid": entry.group_uuid,
+            "string_fields": entry.string_fields,
+        }
+        print(json.dumps(data, indent=2))
+        return
+
+    if fmt == "tsv":
+        print("Field\tValue")
+        print(f"UUID\t{entry.uuid}")
+        print(f"Title\t{entry.name}")
+        print(f"Username\t{entry.login}")
+        print(f"Password\t{password}")
+        print(f"TOTP\t{entry.totp}")
+        print(f"Group\t{entry.group}")
+        print(f"Group UUID\t{entry.group_uuid}")
+        return
+
+    print(f"UUID:       {entry.uuid}")
+    print(f"Title:      {entry.name}")
+    print(f"Username:   {entry.login}")
+    print(f"Password:   {password}")
+    if entry.totp:
+        print(f"TOTP:       {entry.totp}")
+    if entry.group:
+        print(f"Group:      {entry.group}")
+    if entry.group_uuid:
+        print(f"Group UUID: {entry.group_uuid}")
+    if entry.string_fields:
+        for sf in entry.string_fields:
+            for k, v in sf.items():
+                print(f"{k}: {v}")
+
+
+def print_totp(totp: str, fmt: str = "table") -> None:
+    if fmt == "json":
+        print(json.dumps({"totp": totp}, indent=2))
+        return
+    if fmt == "tsv":
+        print(f"TOTP\t{totp}")
+        return
+    print(totp)
+
+
+def print_password(password: str, fmt: str = "table") -> None:
+    if fmt == "json":
+        print(json.dumps({"password": password}, indent=2))
+        return
+    if fmt == "tsv":
+        print(f"Password\t{password}")
+        return
+    print(password)
+
+
+def print_status(info: dict, fmt: str = "table") -> None:
+    if fmt == "json":
+        print(json.dumps(info, indent=2))
+        return
+    if fmt == "tsv":
+        print("Key\tValue")
+        for k, v in info.items():
+            print(f"{k}\t{v}")
+        return
+    for k, v in info.items():
+        print(f"{k}: {v}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68.0", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "keepassxc-cli"
+dynamic = ["version"]
+description = "CLI for KeePassXC using the browser extension protocol with biometric unlock"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+dependencies = [
+    "keepassxc-browser-api>=0.1.0",
+    "pyperclip>=1.8.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+
+[project.scripts]
+keepassxc-cli = "keepassxc_cli.__main__:main"
+
+[tool.setuptools]
+packages = ["keepassxc_cli", "keepassxc_cli.commands"]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api>=0.1.0",
+    "keepassxc-browser-api==0.1.0",
     "pyperclip>=1.8.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+import pytest
+
+from keepassxc_browser_api import Entry, Group, BrowserConfig, Association
+
+
+def make_entry(
+    uuid: str = "abcdef12-0000-0000-0000-000000000000",
+    name: str = "Test Entry",
+    login: str = "user@example.com",
+    password: str = "s3cr3t",
+    totp: str = "",
+    group: str = "Root",
+    group_uuid: str = "root-uuid-0000-0000-0000-000000000000",
+    string_fields: list[dict[str, str]] | None = None,
+) -> Entry:
+    return Entry(
+        uuid=uuid,
+        name=name,
+        login=login,
+        password=password,
+        totp=totp,
+        group=group,
+        group_uuid=group_uuid,
+        string_fields=string_fields or [],
+    )
+
+
+def make_group(
+    uuid: str = "root-uuid-0000-0000-0000-000000000000",
+    name: str = "Root",
+    children: list[Group] | None = None,
+) -> Group:
+    return Group(uuid=uuid, name=name, children=children or [])
+
+
+@pytest.fixture
+def mock_entry():
+    return make_entry
+
+
+@pytest.fixture
+def mock_group():
+    return make_group
+
+
+@pytest.fixture
+def mock_browser_config():
+    assoc = Association(id="test-id", id_key="test-id-key", key="test-key")
+    config = BrowserConfig(
+        client_public_key="pub",
+        client_secret_key="sec",
+        unlock_timeout=30,
+        associations={"test-id": assoc},
+    )
+    return config
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.setup.return_value = True
+    client.connect.return_value = True
+    client.disconnect.return_value = None
+    client.ensure_unlocked.return_value = True
+    client.test_associate.return_value = True
+    client.get_logins.return_value = [make_entry()]
+    client.set_login.return_value = True
+    client.get_database_entries.return_value = [make_entry()]
+    client.get_database_groups.return_value = [make_group()]
+    client.create_group.return_value = make_group(uuid="new-uuid", name="NewGroup")
+    client.get_totp.return_value = "123456"
+    client.delete_entry.return_value = True
+    client.lock_database.return_value = True
+    client.generate_password.return_value = "GeneratedPass123"
+    return client

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from keepassxc_browser_api import Entry, Group, BrowserConfig, Association
+from keepassxc_cli.config import CliConfig
+from keepassxc_cli.commands import (
+    setup, status, show, search, ls, add, edit, rm, totp, clip, generate, lock, mkdir,
+)
+
+
+@pytest.fixture
+def cli_config():
+    return CliConfig()
+
+
+@pytest.fixture
+def browser_config(mock_browser_config):
+    return mock_browser_config
+
+
+@pytest.fixture
+def browser_config_path(tmp_path):
+    return tmp_path / "browser-api.json"
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "show_password": False,
+        "yes": False,
+        "groups": False,
+        "field": "password",
+        "clip": False,
+        "url": "https://example.com",
+        "username": "user",
+        "password": "pass",
+        "title": "Example",
+        "group_uuid": "",
+        "uuid": "abcdef12-0000-0000-0000-000000000000",
+        "query": "test",
+        "name": "NewGroup",
+        "parent_uuid": "",
+        "length": 20,
+        "no_numbers": False,
+        "no_lowercase": False,
+        "no_uppercase": False,
+        "symbols": False,
+        "special": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# --- setup ---
+
+class TestSetupCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path):
+        mock_client.setup.return_value = True
+        args = make_args()
+        rc = setup.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.setup.assert_called_once()
+
+    def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.setup.return_value = False
+        args = make_args()
+        rc = setup.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert "Failed" in capsys.readouterr().err
+
+
+# --- status ---
+
+class TestStatusCommand:
+    def test_connected_and_associated(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.connect.return_value = True
+        mock_client.test_associate.return_value = True
+        args = make_args()
+        rc = status.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "yes" in out
+
+    def test_not_connected(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.connect.return_value = False
+        args = make_args()
+        rc = status.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "no" in out
+
+    def test_not_associated(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.connect.return_value = True
+        mock_client.test_associate.return_value = False
+        args = make_args()
+        rc = status.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "no" in out
+
+
+# --- show ---
+
+class TestShowCommand:
+    def test_found_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry()
+        mock_client.get_logins.return_value = [entry]
+        args = make_args(url="https://example.com", show_password=False)
+        rc = show.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Test Entry" in out
+
+    def test_no_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_logins.return_value = []
+        args = make_args(url="https://notfound.com")
+        rc = show.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert "No entries" in capsys.readouterr().err
+
+
+# --- search ---
+
+class TestSearchCommand:
+    def test_matches_found(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry(name="GitHub", login="user@github.com")
+        mock_client.get_database_entries.return_value = [entry]
+        args = make_args(query="github")
+        rc = search.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "GitHub" in capsys.readouterr().out
+
+    def test_no_matches(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry(name="GitHub")
+        mock_client.get_database_entries.return_value = [entry]
+        args = make_args(query="zzznomatch")
+        rc = search.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert "No entries" in capsys.readouterr().err
+
+
+# --- ls ---
+
+class TestLsCommand:
+    def test_list_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        mock_client.get_database_entries.return_value = [mock_entry()]
+        args = make_args(groups=False)
+        rc = ls.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "Test Entry" in capsys.readouterr().out
+
+    def test_list_groups(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        mock_client.get_database_groups.return_value = [mock_group()]
+        args = make_args(groups=True)
+        rc = ls.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "Root" in capsys.readouterr().out
+
+
+# --- add ---
+
+class TestAddCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.set_login.return_value = True
+        args = make_args(url="https://example.com", username="u", password="p", title="T", group_uuid="")
+        rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.set_login.assert_called_once()
+        assert "added" in capsys.readouterr().out.lower()
+
+    def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.set_login.return_value = False
+        args = make_args(url="https://example.com", username="u", password="p", title="T", group_uuid="")
+        rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+
+# --- edit ---
+
+class TestEditCommand:
+    def test_entry_found_and_updated(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry()
+        mock_client.get_database_entries.return_value = [entry]
+        mock_client.set_login.return_value = True
+        args = make_args(uuid=entry.uuid, url=None, username="newuser", password=None, title=None)
+        rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "updated" in capsys.readouterr().out.lower()
+
+    def test_entry_not_found(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_database_entries.return_value = []
+        args = make_args(uuid="nonexistent-uuid", url=None, username=None, password=None, title=None)
+        rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err.lower()
+
+
+# --- rm ---
+
+class TestRmCommand:
+    def test_with_yes_flag(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.delete_entry.return_value = True
+        args = make_args(uuid="some-uuid", yes=True)
+        rc = rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.delete_entry.assert_called_once_with("some-uuid")
+        assert "deleted" in capsys.readouterr().out.lower()
+
+    def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.delete_entry.return_value = False
+        args = make_args(uuid="some-uuid", yes=True)
+        rc = rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+
+# --- totp ---
+
+class TestTotpCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_totp.return_value = "654321"
+        args = make_args(uuid="some-uuid")
+        rc = totp.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "654321" in capsys.readouterr().out
+
+    def test_no_totp(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_totp.return_value = None
+        args = make_args(uuid="some-uuid")
+        rc = totp.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+
+# --- clip ---
+
+class TestClipCommand:
+    def test_password_copied(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry(password="secret123")
+        mock_client.get_logins.return_value = [entry]
+        args = make_args(url="https://example.com", field="password")
+        with patch.dict("sys.modules", {"pyperclip": MagicMock()}):
+            import pyperclip
+            rc = clip.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+
+    def test_no_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_logins.return_value = []
+        args = make_args(url="https://notfound.com", field="password")
+        with patch.dict("sys.modules", {"pyperclip": MagicMock()}):
+            rc = clip.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+    def test_pyperclip_missing(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        args = make_args(url="https://example.com", field="password")
+        with patch.dict("sys.modules", {"pyperclip": None}):
+            rc = clip.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert "pyperclip" in capsys.readouterr().err
+
+
+# --- generate ---
+
+class TestGenerateCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.generate_password.return_value = "GenPass123!"
+        args = make_args(length=20, no_numbers=False, no_lowercase=False, no_uppercase=False, symbols=False, special=False, clip=False)
+        rc = generate.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "GenPass123!" in capsys.readouterr().out
+
+    def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.generate_password.return_value = None
+        args = make_args(length=20, no_numbers=False, no_lowercase=False, no_uppercase=False, symbols=False, special=False, clip=False)
+        rc = generate.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+    def test_clip(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.generate_password.return_value = "GenPass123!"
+        args = make_args(length=20, no_numbers=False, no_lowercase=False, no_uppercase=False, symbols=False, special=False, clip=True)
+        with patch.dict("sys.modules", {"pyperclip": MagicMock()}):
+            rc = generate.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+
+
+# --- lock ---
+
+class TestLockCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.lock_database.return_value = True
+        args = make_args()
+        rc = lock.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "locked" in capsys.readouterr().out.lower()
+
+    def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.lock_database.return_value = False
+        args = make_args()
+        rc = lock.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+
+# --- mkdir ---
+
+class TestMkdirCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        new_group = mock_group(uuid="new-uuid", name="MyGroup")
+        mock_client.create_group.return_value = new_group
+        args = make_args(name="MyGroup", parent_uuid="")
+        rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "MyGroup" in out
+
+    def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.create_group.return_value = None
+        args = make_args(name="MyGroup", parent_uuid="")
+        rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -45,12 +45,6 @@ def make_args(**kwargs) -> argparse.Namespace:
         "query": "test",
         "name": "NewGroup",
         "parent_uuid": "",
-        "length": 20,
-        "no_numbers": False,
-        "no_lowercase": False,
-        "no_uppercase": False,
-        "symbols": False,
-        "special": False,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -267,20 +261,20 @@ class TestClipCommand:
 class TestGenerateCommand:
     def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.generate_password.return_value = "GenPass123!"
-        args = make_args(length=20, no_numbers=False, no_lowercase=False, no_uppercase=False, symbols=False, special=False, clip=False)
+        args = make_args(clip=False)
         rc = generate.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         assert "GenPass123!" in capsys.readouterr().out
 
     def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.generate_password.return_value = None
-        args = make_args(length=20, no_numbers=False, no_lowercase=False, no_uppercase=False, symbols=False, special=False, clip=False)
+        args = make_args(clip=False)
         rc = generate.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
 
     def test_clip(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.generate_password.return_value = "GenPass123!"
-        args = make_args(length=20, no_numbers=False, no_lowercase=False, no_uppercase=False, symbols=False, special=False, clip=True)
+        args = make_args(clip=True)
         with patch.dict("sys.modules", {"pyperclip": MagicMock()}):
             rc = generate.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from keepassxc_cli.config import CliConfig, DEFAULT_BROWSER_API_CONFIG_PATH, DEFAULT_CLI_CONFIG_PATH
+
+
+def test_default_values():
+    config = CliConfig()
+    assert config.browser_api_config_path == DEFAULT_BROWSER_API_CONFIG_PATH
+    assert config.default_format == "table"
+
+
+def test_to_dict_defaults_omitted():
+    config = CliConfig()
+    d = config.to_dict()
+    assert d == {}
+
+
+def test_to_dict_non_defaults_included():
+    config = CliConfig(browser_api_config_path="/custom/path.json", default_format="json")
+    d = config.to_dict()
+    assert d["browser_api_config_path"] == "/custom/path.json"
+    assert d["default_format"] == "json"
+
+
+def test_from_dict_roundtrip():
+    config = CliConfig(browser_api_config_path="/custom/path.json", default_format="tsv")
+    restored = CliConfig.from_dict(config.to_dict())
+    assert restored.browser_api_config_path == config.browser_api_config_path
+    assert restored.default_format == config.default_format
+
+
+def test_from_dict_defaults_on_empty():
+    config = CliConfig.from_dict({})
+    assert config.browser_api_config_path == DEFAULT_BROWSER_API_CONFIG_PATH
+    assert config.default_format == "table"
+
+
+def test_save_and_load(tmp_path):
+    config = CliConfig(browser_api_config_path="/custom/path.json", default_format="json")
+    save_path = tmp_path / "cli.json"
+    config.save(save_path)
+
+    assert save_path.exists()
+    # Check file permissions are 0o600
+    mode = stat.S_IMODE(os.stat(save_path).st_mode)
+    assert mode == 0o600
+
+    loaded = CliConfig.load(save_path)
+    assert loaded.browser_api_config_path == config.browser_api_config_path
+    assert loaded.default_format == config.default_format
+
+
+def test_load_nonexistent_returns_defaults(tmp_path):
+    path = tmp_path / "nonexistent.json"
+    config = CliConfig.load(path)
+    assert config.browser_api_config_path == DEFAULT_BROWSER_API_CONFIG_PATH
+    assert config.default_format == "table"
+
+
+def test_save_creates_parent_dirs(tmp_path):
+    path = tmp_path / "deep" / "nested" / "cli.json"
+    config = CliConfig()
+    config.save(path)
+    assert path.exists()
+
+
+def test_save_defaults_writes_empty_dict(tmp_path):
+    config = CliConfig()
+    path = tmp_path / "cli.json"
+    config.save(path)
+    with open(path) as f:
+        data = json.load(f)
+    assert data == {}

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from keepassxc_browser_api import Entry, Group
+from keepassxc_cli.output import (
+    print_entries,
+    print_groups,
+    print_entry_detail,
+    print_totp,
+    print_password,
+    print_status,
+)
+
+
+@pytest.fixture
+def sample_entry():
+    return Entry(
+        uuid="abcdef12-0000-0000-0000-000000000000",
+        name="GitHub",
+        login="user@example.com",
+        password="s3cr3t",
+        totp="",
+        group="Root",
+        group_uuid="root-uuid",
+        string_fields=[{"KPH: url": "https://github.com"}],
+    )
+
+
+@pytest.fixture
+def sample_group():
+    child = Group(uuid="child-uuid", name="Personal", children=[])
+    return Group(uuid="root-uuid", name="Root", children=[child])
+
+
+class TestPrintEntries:
+    def test_table_format(self, capsys, sample_entry):
+        print_entries([sample_entry], fmt="table")
+        out = capsys.readouterr().out
+        assert "GitHub" in out
+        assert "user@example.com" in out
+        assert "Root" in out
+        assert "abcdef12…" in out  # truncated UUID (8 chars + ellipsis)
+
+    def test_json_format(self, capsys, sample_entry):
+        print_entries([sample_entry], fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 1
+        assert data[0]["name"] == "GitHub"
+        assert data[0]["login"] == "user@example.com"
+        assert data[0]["password"] == "***"
+
+    def test_json_format_show_password(self, capsys, sample_entry):
+        print_entries([sample_entry], fmt="json", show_password=True)
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data[0]["password"] == "s3cr3t"
+
+    def test_tsv_format(self, capsys, sample_entry):
+        print_entries([sample_entry], fmt="tsv")
+        out = capsys.readouterr().out
+        lines = out.strip().split("\n")
+        assert lines[0] == "UUID\tTitle\tUsername\tURL\tGroup"
+        assert "GitHub" in lines[1]
+        assert "user@example.com" in lines[1]
+
+    def test_table_format_multiple_entries(self, capsys, sample_entry):
+        entries = [sample_entry, sample_entry]
+        print_entries(entries, fmt="table")
+        out = capsys.readouterr().out
+        assert out.count("GitHub") == 2
+
+
+class TestPrintGroups:
+    def test_table_format(self, capsys, sample_group):
+        print_groups([sample_group], fmt="table")
+        out = capsys.readouterr().out
+        assert "Root" in out
+        assert "Personal" in out
+
+    def test_json_format(self, capsys, sample_group):
+        print_groups([sample_group], fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data[0]["name"] == "Root"
+        assert data[0]["children"][0]["name"] == "Personal"
+
+    def test_tsv_format(self, capsys, sample_group):
+        # flat_list must work; the Group dataclass has flat_list method
+        print_groups([sample_group], fmt="tsv")
+        out = capsys.readouterr().out
+        lines = out.strip().split("\n")
+        assert lines[0] == "UUID\tName"
+
+
+class TestPrintEntryDetail:
+    def test_table_format(self, capsys, sample_entry):
+        print_entry_detail(sample_entry, fmt="table", show_password=False)
+        out = capsys.readouterr().out
+        assert "GitHub" in out
+        assert "user@example.com" in out
+        assert "***" in out
+
+    def test_table_format_show_password(self, capsys, sample_entry):
+        print_entry_detail(sample_entry, fmt="table", show_password=True)
+        out = capsys.readouterr().out
+        assert "s3cr3t" in out
+
+    def test_json_format(self, capsys, sample_entry):
+        print_entry_detail(sample_entry, fmt="json", show_password=True)
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["name"] == "GitHub"
+        assert data["password"] == "s3cr3t"
+
+    def test_tsv_format(self, capsys, sample_entry):
+        print_entry_detail(sample_entry, fmt="tsv")
+        out = capsys.readouterr().out
+        assert "Title\tGitHub" in out
+
+
+class TestPrintTotp:
+    def test_table_format(self, capsys):
+        print_totp("123456", fmt="table")
+        assert capsys.readouterr().out.strip() == "123456"
+
+    def test_json_format(self, capsys):
+        print_totp("123456", fmt="json")
+        data = json.loads(capsys.readouterr().out)
+        assert data["totp"] == "123456"
+
+    def test_tsv_format(self, capsys):
+        print_totp("123456", fmt="tsv")
+        assert "TOTP\t123456" in capsys.readouterr().out
+
+
+class TestPrintPassword:
+    def test_table_format(self, capsys):
+        print_password("mypass", fmt="table")
+        assert capsys.readouterr().out.strip() == "mypass"
+
+    def test_json_format(self, capsys):
+        print_password("mypass", fmt="json")
+        data = json.loads(capsys.readouterr().out)
+        assert data["password"] == "mypass"
+
+
+class TestPrintStatus:
+    def test_table_format(self, capsys):
+        print_status({"Connected": "yes", "Associated": "no"}, fmt="table")
+        out = capsys.readouterr().out
+        assert "Connected: yes" in out
+        assert "Associated: no" in out
+
+    def test_json_format(self, capsys):
+        print_status({"Connected": "yes"}, fmt="json")
+        data = json.loads(capsys.readouterr().out)
+        assert data["Connected"] == "yes"


### PR DESCRIPTION
## Summary

Introduces `keepassxc-cli` — a CLI tool with the same feature set as `keepassxc-cli` (bundled with KeePassXC) but using the browser extension API and TouchID/biometrics unlock instead of requiring the database password.

## Features

- **13 commands**: `setup`, `status`, `show`, `search`, `ls`, `add`, `edit`, `rm`, `totp`, `clip`, `generate`, `lock`, `mkdir`
- **3 output formats**: table, json, tsv (via `--format`)
- **Shared config** with `keepassxc-ssh-agent` (both read `~/.keepassxc/browser-api.json`)
- 57 tests, CI workflows (lint, auto-release, auto-merge-dependabot, pypi)

## Dependency

Requires `keepassxc-browser-api==0.1.0` to be published on PyPI (released as part of this deployment).