### PR TITLE
fix: bump keepassxc-browser-api to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==0.1.0",
+    "keepassxc-browser-api==0.1.1",
     "pyperclip>=1.8.0",
 ]
 


### PR DESCRIPTION
Picks up the bug fixes from keepassxc-browser-api v0.1.1:
- call `test-associate` after key exchange (fixes all commands silently failing)
- handle concatenated JSON from lock-database broadcast (fixes `lock` command)
- WARNING-level error logging