### PR TITLE
fix: bump keepassxc-browser-api to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==0.1.1",
+    "keepassxc-browser-api==0.1.2",
     "pyperclip>=1.8.0",
 ]
 


### PR DESCRIPTION
Picks up v0.1.2 bug fixes: recursion crash fix, auto-unlock, lock-database response handling.