### PR TITLE
fix: -j/--json flag, TOTP hidden by default, search via get-logins, clip/totp accept URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,21 @@ This performs a key exchange with KeePassXC (you will be prompted to allow the a
 ### Global options
 
 ```
-keepassxc-cli [--config PATH] [--browser-api-config PATH] [--format {table,json,tsv}] [-v] COMMAND
+keepassxc-cli [--config PATH] [--browser-api-config PATH] [-v] COMMAND [COMMAND OPTIONS]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--config` | Path to CLI config file (default: `~/.keepassxc/cli.json`) |
 | `--browser-api-config` | Path to browser API config file (default: `~/.keepassxc/browser-api.json`) |
-| `--format` | Output format: `table` (default), `json`, or `tsv` |
 | `-v, --verbose` | Enable verbose/debug logging |
+
+Most commands support a `-j / --json` flag for JSON output — pass it anywhere after the subcommand name:
+
+```bash
+keepassxc-cli show https://github.com -j
+keepassxc-cli ls -j
+```
 
 ### Commands
 
@@ -69,80 +75,90 @@ keepassxc-cli setup
 
 ```bash
 keepassxc-cli status
+keepassxc-cli status -j
 ```
 
-#### `ls` — List entries or groups
+#### `ls` — List all entries or groups
+
+> **Requires** "Allow access to all entries" to be enabled in  
+> KeePassXC → Settings → Browser Integration.
 
 ```bash
-keepassxc-cli ls                # list all entries (includes UUID column)
-keepassxc-cli ls --groups       # list groups (tree view)
-keepassxc-cli ls --format json  # output as JSON
+keepassxc-cli ls              # list all entries (includes UUID column)
+keepassxc-cli ls --groups     # list groups as a tree
+keepassxc-cli ls -j           # output as JSON
 ```
 
-UUIDs shown in the output are needed for `edit`, `rm`, `totp`, and `clip --field totp`.
+The UUIDs shown here are needed for `edit` and `rm`.
 
-#### `search` — Search entries
+#### `search` — Search entries by URL or hostname
 
 ```bash
-keepassxc-cli search github
-keepassxc-cli search "my bank" --show-password
+keepassxc-cli search github.com
+keepassxc-cli search https://github.com -p   # reveal passwords
+keepassxc-cli search github.com -j
 ```
 
-Searches case-insensitively across title, username, and URL fields.
+KeePassXC matches entries by URL/hostname (the same mechanism the browser extension uses).
 
 #### `show` — Show entries for a URL
 
 ```bash
 keepassxc-cli show https://github.com
-keepassxc-cli show https://github.com -p   # reveal password
+keepassxc-cli show https://github.com -p     # reveal password and TOTP
+keepassxc-cli show https://github.com -j
+```
+
+#### `totp` — Get TOTP code
+
+```bash
+keepassxc-cli totp https://github.com
+keepassxc-cli totp https://github.com -j
+```
+
+#### `clip` — Copy a field to clipboard
+
+```bash
+keepassxc-cli clip password https://github.com
+keepassxc-cli clip username https://github.com
+keepassxc-cli clip totp     https://github.com
 ```
 
 #### `add` — Add a new entry
 
 ```bash
 keepassxc-cli add --url https://example.com --username user@example.com --title "Example"
-# Password will be prompted securely if --password is not given
+# Password is prompted securely if --password is not given
 keepassxc-cli add --url https://example.com --username user --password mypass
 ```
 
 #### `edit` — Edit an entry
 
-> **Finding a UUID**: Use `keepassxc-cli ls` or `keepassxc-cli search <query>` to list entries with their UUIDs.
-
 ```bash
-keepassxc-cli edit <uuid> --username newuser
-keepassxc-cli edit <uuid> --password newpass --title "New Title"
+# Get the UUID first
+keepassxc-cli show https://github.com
+
+# Then edit — --url is required to resolve the current entry
+keepassxc-cli edit <uuid> --url https://github.com --username newuser
+keepassxc-cli edit <uuid> --url https://github.com --password newpass --title "New Title"
 ```
 
 #### `rm` — Delete an entry
 
 ```bash
-keepassxc-cli rm <uuid>          # prompts for confirmation
-keepassxc-cli rm <uuid> --yes    # skip confirmation
-```
-
-#### `totp` — Get TOTP code
-
-```bash
-keepassxc-cli totp <uuid>
-```
-
-#### `clip` — Copy to clipboard
-
-```bash
-keepassxc-cli clip https://github.com              # copies password
-keepassxc-cli clip https://github.com --field username
-keepassxc-cli clip https://github.com --field totp
+keepassxc-cli rm <uuid>        # prompts for confirmation
+keepassxc-cli rm <uuid> --yes  # skip confirmation
 ```
 
 #### `generate` — Generate a password
 
 ```bash
-keepassxc-cli generate
-keepassxc-cli generate --length 32 --symbols
-keepassxc-cli generate --no-numbers --no-uppercase
-keepassxc-cli generate --clip    # copy to clipboard instead of printing
+keepassxc-cli generate             # prints a password
+keepassxc-cli generate --clip      # copy to clipboard instead
+keepassxc-cli generate -j
 ```
+
+KeePassXC uses its own configured password generator profile (set in KeePassXC → Tools → Password Generator).
 
 #### `lock` — Lock the database
 
@@ -166,7 +182,7 @@ Only non-default values are stored. Available options:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `browser_api_config_path` | `~/.keepassxc/browser-api.json` | Path to the browser API config |
-| `default_format` | `table` | Default output format (`table`, `json`, `tsv`) |
+| `default_format` | `table` | Default output format (`table` or `json`) |
 
 Example `~/.keepassxc/cli.json`:
 ```json
@@ -206,6 +222,7 @@ ruff check --ignore=E501 --exclude=__init__.py ./keepassxc_cli
 ## Known Limitations
 
 - Requires KeePassXC to be **running** and the database to be **open** (or biometric auto-unlock configured).
+- The `ls` command requires "Allow access to all entries" to be enabled in KeePassXC → Settings → Browser Integration.
 - The `clip` and `generate --clip` commands require `pyperclip` and a working clipboard (e.g., `xclip`/`xsel` on Linux, built-in on macOS/Windows).
 - The browser integration protocol does not support moving entries between groups directly.
-- Entry URLs in the database are stored as `KPH: url` string fields; entries without a URL field may not appear in `show` results.
+- Entry URLs in the database are stored as `KPH: url` string fields; entries without a URL field may not appear in `show`/`search` results.

--- a/keepassxc_cli/__main__.py
+++ b/keepassxc_cli/__main__.py
@@ -13,6 +13,17 @@ from keepassxc_browser_api.exceptions import KeePassXCError, ConnectionError
 from .config import CliConfig, DEFAULT_CLI_CONFIG_PATH
 from .commands import setup, status, show, search, ls, add, edit, rm, totp, clip, generate, lock, mkdir
 
+# Shared parent parser that injects -j/--json into each subparser that supports it.
+# Defined at module level so command modules can import it if needed.
+fmt_parent = argparse.ArgumentParser(add_help=False)
+fmt_parent.add_argument(
+    "-j", "--json",
+    action="store_true",
+    dest="json_output",
+    default=False,
+    help="Output as JSON",
+)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -29,29 +40,22 @@ def main() -> None:
         default=None,
         help="Path to browser API config file",
     )
-    parser.add_argument(
-        "--format",
-        choices=["table", "json", "tsv"],
-        default=None,
-        dest="fmt",
-        help="Output format (default: table)",
-    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
 
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
     subparsers.required = True
 
     setup.add_parser(subparsers)
-    status.add_parser(subparsers)
-    show.add_parser(subparsers)
-    search.add_parser(subparsers)
-    ls.add_parser(subparsers)
+    status.add_parser(subparsers, fmt_parent)
+    show.add_parser(subparsers, fmt_parent)
+    search.add_parser(subparsers, fmt_parent)
+    ls.add_parser(subparsers, fmt_parent)
     add.add_parser(subparsers)
     edit.add_parser(subparsers)
     rm.add_parser(subparsers)
-    totp.add_parser(subparsers)
+    totp.add_parser(subparsers, fmt_parent)
     clip.add_parser(subparsers)
-    generate.add_parser(subparsers)
+    generate.add_parser(subparsers, fmt_parent)
     lock.add_parser(subparsers)
     mkdir.add_parser(subparsers)
 
@@ -66,7 +70,7 @@ def main() -> None:
     browser_api_config_path = Path(args.browser_api_config or cli_config.browser_api_config_path)
     browser_config = BrowserConfig.load(browser_api_config_path)
 
-    fmt = args.fmt or cli_config.default_format
+    fmt = "json" if getattr(args, "json_output", False) else cli_config.default_format
 
     client = BrowserClient(browser_config)
     try:

--- a/keepassxc_cli/commands/clip.py
+++ b/keepassxc_cli/commands/clip.py
@@ -49,7 +49,7 @@ def run(
     elif args.field == "totp":
         value = client.get_totp(entry.uuid)
         if value is None:
-            print(f"No TOTP for entry: {entry.uuid}", file=sys.stderr)
+            print(f"No TOTP configured for: {entry.name}", file=sys.stderr)
             return 1
     else:
         print(f"Unknown field: {args.field}", file=sys.stderr)

--- a/keepassxc_cli/commands/clip.py
+++ b/keepassxc_cli/commands/clip.py
@@ -11,13 +11,12 @@ from keepassxc_cli.config import CliConfig
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser("clip", help="Copy a field to clipboard")
-    p.add_argument("url", help="URL to look up")
     p.add_argument(
-        "--field",
+        "field",
         choices=["password", "username", "totp"],
-        default="password",
-        help="Field to copy (default: password)",
+        help="Field to copy: password, username, or totp",
     )
+    p.add_argument("url", help="URL to look up")
     p.set_defaults(func=run)
 
 

--- a/keepassxc_cli/commands/edit.py
+++ b/keepassxc_cli/commands/edit.py
@@ -10,9 +10,16 @@ from keepassxc_cli.config import CliConfig
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("edit", help="Edit an existing entry by UUID")
+    p = subparsers.add_parser(
+        "edit",
+        help="Edit an existing entry by UUID",
+        description=(
+            "Edit an existing entry. The UUID must be known (use 'ls' or 'show' to find it).\n"
+            "Provide --url so the entry can be resolved; omitted fields are left unchanged."
+        ),
+    )
     p.add_argument("uuid", help="UUID of the entry to edit")
-    p.add_argument("--url", default=None, help="New URL")
+    p.add_argument("--url", required=True, help="URL of the entry (used to resolve current values)")
     p.add_argument("--username", default=None, help="New username")
     p.add_argument("--password", default=None, help="New password")
     p.add_argument("--title", default=None, help="New title")
@@ -28,20 +35,19 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    all_entries = client.get_database_entries()
-    entry = next((e for e in all_entries if e.uuid == args.uuid), None)
+    # Resolve current entry values via get_logins (no special permission needed)
+    entries = client.get_logins(args.url)
+    entry = next((e for e in entries if e.uuid == args.uuid), None)
     if entry is None:
-        print(f"Entry not found: {args.uuid}", file=sys.stderr)
+        print(
+            f"Entry {args.uuid} not found for URL: {args.url}\n"
+            "Hint: use 'keepassxc-cli show <url>' to look up the UUID.",
+            file=sys.stderr,
+        )
         return 1
 
-    # Determine the URL to use for set_login (required by the API)
-    url = args.url or next(
-        (sf.get("KPH: url", "") for sf in entry.string_fields if "KPH: url" in sf),
-        "",
-    )
-
     success = client.set_login(
-        url=url,
+        url=args.url,
         username=args.username if args.username is not None else entry.login,
         password=args.password if args.password is not None else entry.password,
         title=args.title if args.title is not None else entry.name,

--- a/keepassxc_cli/commands/generate.py
+++ b/keepassxc_cli/commands/generate.py
@@ -10,9 +10,11 @@ from keepassxc_cli.config import CliConfig
 from keepassxc_cli.output import print_password
 
 
-def add_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
     p = subparsers.add_parser(
         "generate",
+        parents=parents,
         help="Generate a password using KeePassXC's configured password profile",
     )
     p.add_argument("--clip", action="store_true", help="Copy to clipboard instead of printing")

--- a/keepassxc_cli/commands/ls.py
+++ b/keepassxc_cli/commands/ls.py
@@ -11,7 +11,16 @@ from keepassxc_cli.output import print_entries, print_groups
 
 def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
     parents = [fmt_parent] if fmt_parent else []
-    p = subparsers.add_parser("ls", parents=parents, help="List database entries or groups")
+    p = subparsers.add_parser(
+        "ls",
+        parents=parents,
+        help="List all database entries or groups",
+        description=(
+            "List all entries or groups in the open database.\n\n"
+            "NOTE: requires 'Allow access to all entries' to be enabled in\n"
+            "KeePassXC → Settings → Browser Integration."
+        ),
+    )
     p.add_argument("--groups", action="store_true", help="List groups instead of entries")
     p.set_defaults(func=run)
 

--- a/keepassxc_cli/commands/ls.py
+++ b/keepassxc_cli/commands/ls.py
@@ -9,8 +9,9 @@ from keepassxc_cli.config import CliConfig
 from keepassxc_cli.output import print_entries, print_groups
 
 
-def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("ls", help="List database entries or groups")
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
+    p = subparsers.add_parser("ls", parents=parents, help="List database entries or groups")
     p.add_argument("--groups", action="store_true", help="List groups instead of entries")
     p.set_defaults(func=run)
 

--- a/keepassxc_cli/commands/search.py
+++ b/keepassxc_cli/commands/search.py
@@ -10,10 +10,15 @@ from keepassxc_cli.config import CliConfig
 from keepassxc_cli.output import print_entries
 
 
-def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("search", help="Search all database entries")
-    p.add_argument("query", help="Search query (case-insensitive match on title, username, or URL)")
-    p.add_argument("-p", "--show-password", action="store_true", help="Reveal password")
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
+    p = subparsers.add_parser(
+        "search",
+        parents=parents,
+        help="Search database entries by URL or hostname",
+    )
+    p.add_argument("query", help="URL or hostname to search for")
+    p.add_argument("-p", "--show-password", action="store_true", help="Reveal passwords")
     p.set_defaults(func=run)
 
 
@@ -26,16 +31,9 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    query = args.query.lower()
-    all_entries = client.get_database_entries()
-    matches = [
-        e for e in all_entries
-        if query in e.name.lower()
-        or query in e.login.lower()
-        or any(query in v.lower() for sf in e.string_fields for v in sf.values() if v is not None)
-    ]
-    if not matches:
+    entries = client.get_logins(args.query)
+    if not entries:
         print(f"No entries found matching: {args.query}", file=sys.stderr)
         return 1
-    print_entries(matches, fmt, show_password=args.show_password)
+    print_entries(entries, fmt, show_password=args.show_password)
     return 0

--- a/keepassxc_cli/commands/show.py
+++ b/keepassxc_cli/commands/show.py
@@ -10,10 +10,11 @@ from keepassxc_cli.config import CliConfig
 from keepassxc_cli.output import print_entry_detail
 
 
-def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("show", help="Show entries matching a URL")
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
+    p = subparsers.add_parser("show", parents=parents, help="Show entries matching a URL")
     p.add_argument("url", help="URL or search string")
-    p.add_argument("-p", "--show-password", action="store_true", help="Reveal password")
+    p.add_argument("-p", "--show-password", action="store_true", help="Reveal password and TOTP")
     p.set_defaults(func=run)
 
 

--- a/keepassxc_cli/commands/status.py
+++ b/keepassxc_cli/commands/status.py
@@ -10,8 +10,9 @@ from keepassxc_cli.config import CliConfig
 from keepassxc_cli.output import print_status
 
 
-def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("status", help="Show KeePassXC connection and association status")
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
+    p = subparsers.add_parser("status", parents=parents, help="Show KeePassXC connection and association status")
     p.set_defaults(func=run)
 
 

--- a/keepassxc_cli/commands/totp.py
+++ b/keepassxc_cli/commands/totp.py
@@ -10,9 +10,10 @@ from keepassxc_cli.config import CliConfig
 from keepassxc_cli.output import print_totp
 
 
-def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("totp", help="Get TOTP code for an entry")
-    p.add_argument("uuid", help="UUID of the entry")
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
+    p = subparsers.add_parser("totp", parents=parents, help="Get TOTP code for an entry")
+    p.add_argument("url", help="URL to look up")
     p.set_defaults(func=run)
 
 
@@ -25,9 +26,14 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    totp = client.get_totp(args.uuid)
+    entries = client.get_logins(args.url)
+    if not entries:
+        print(f"No entries found for: {args.url}", file=sys.stderr)
+        return 1
+    entry = entries[0]
+    totp = client.get_totp(entry.uuid)
     if totp is None:
-        print(f"No TOTP for entry: {args.uuid}", file=sys.stderr)
+        print(f"No TOTP configured for: {entry.name}", file=sys.stderr)
         return 1
     print_totp(totp, fmt)
     return 0

--- a/keepassxc_cli/output.py
+++ b/keepassxc_cli/output.py
@@ -49,14 +49,6 @@ def print_entries(entries: list[Entry], fmt: str = "table", show_password: bool 
         print(json.dumps(data, indent=2))
         return
 
-    if fmt == "tsv":
-        headers = ["UUID", "Title", "Username", "URL", "Group"]
-        print("\t".join(headers))
-        for e in entries:
-            url = next((sf.get("KPH: url", "") for sf in e.string_fields if "KPH: url" in sf), "")
-            print("\t".join([e.uuid, e.name, e.login, url, e.group]))
-        return
-
     # table
     headers = ["UUID", "Title", "Username", "URL", "Group"]
     rows = []
@@ -80,50 +72,34 @@ def print_groups(groups: list[Group], fmt: str = "table") -> None:
         print(json.dumps([_g2d(g) for g in groups], indent=2))
         return
 
-    if fmt == "tsv":
-        print("UUID\tName")
-        for g in groups:
-            for flat in g.flat_list():
-                print(f"{flat.uuid}\t{flat.name}")
-        return
-
     for g in groups:
         _print_group_tree(g)
 
 
 def print_entry_detail(entry: Entry, fmt: str = "table", show_password: bool = False) -> None:
     password = entry.password if show_password else "***"
+    totp = entry.totp if show_password else None
     if fmt == "json":
         data = {
             "uuid": entry.uuid,
             "name": entry.name,
             "login": entry.login,
             "password": password,
-            "totp": entry.totp,
             "group": entry.group,
             "group_uuid": entry.group_uuid,
             "string_fields": entry.string_fields,
         }
+        if totp is not None:
+            data["totp"] = totp
         print(json.dumps(data, indent=2))
-        return
-
-    if fmt == "tsv":
-        print("Field\tValue")
-        print(f"UUID\t{entry.uuid}")
-        print(f"Title\t{entry.name}")
-        print(f"Username\t{entry.login}")
-        print(f"Password\t{password}")
-        print(f"TOTP\t{entry.totp}")
-        print(f"Group\t{entry.group}")
-        print(f"Group UUID\t{entry.group_uuid}")
         return
 
     print(f"UUID:       {entry.uuid}")
     print(f"Title:      {entry.name}")
     print(f"Username:   {entry.login}")
     print(f"Password:   {password}")
-    if entry.totp:
-        print(f"TOTP:       {entry.totp}")
+    if totp:
+        print(f"TOTP:       {totp}")
     if entry.group:
         print(f"Group:      {entry.group}")
     if entry.group_uuid:
@@ -138,9 +114,6 @@ def print_totp(totp: str, fmt: str = "table") -> None:
     if fmt == "json":
         print(json.dumps({"totp": totp}, indent=2))
         return
-    if fmt == "tsv":
-        print(f"TOTP\t{totp}")
-        return
     print(totp)
 
 
@@ -148,20 +121,12 @@ def print_password(password: str, fmt: str = "table") -> None:
     if fmt == "json":
         print(json.dumps({"password": password}, indent=2))
         return
-    if fmt == "tsv":
-        print(f"Password\t{password}")
-        return
     print(password)
 
 
 def print_status(info: dict, fmt: str = "table") -> None:
     if fmt == "json":
         print(json.dumps(info, indent=2))
-        return
-    if fmt == "tsv":
-        print("Key\tValue")
-        for k, v in info.items():
-            print(f"{k}\t{v}")
         return
     for k, v in info.items():
         print(f"{k}: {v}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api>=0.1.3",
-    "pyperclip>=1.8.0",
+    "keepassxc-browser-api==0.1.3",
+    "pyperclip==1.8.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==0.1.2",
+    "keepassxc-browser-api>=0.1.3",
     "pyperclip>=1.8.0",
 ]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -123,16 +123,15 @@ class TestShowCommand:
 class TestSearchCommand:
     def test_matches_found(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
         entry = mock_entry(name="GitHub", login="user@github.com")
-        mock_client.get_database_entries.return_value = [entry]
-        args = make_args(query="github")
+        mock_client.get_logins.return_value = [entry]
+        args = make_args(query="github.com")
         rc = search.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         assert "GitHub" in capsys.readouterr().out
 
-    def test_no_matches(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
-        entry = mock_entry(name="GitHub")
-        mock_client.get_database_entries.return_value = [entry]
-        args = make_args(query="zzznomatch")
+    def test_no_matches(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_logins.return_value = []
+        args = make_args(query="zzznomatch.com")
         rc = search.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
         assert "No entries" in capsys.readouterr().err
@@ -179,16 +178,16 @@ class TestAddCommand:
 class TestEditCommand:
     def test_entry_found_and_updated(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
         entry = mock_entry()
-        mock_client.get_database_entries.return_value = [entry]
+        mock_client.get_logins.return_value = [entry]
         mock_client.set_login.return_value = True
-        args = make_args(uuid=entry.uuid, url=None, username="newuser", password=None, title=None)
+        args = make_args(uuid=entry.uuid, url="https://example.com", username="newuser", password=None, title=None)
         rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         assert "updated" in capsys.readouterr().out.lower()
 
     def test_entry_not_found(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
-        mock_client.get_database_entries.return_value = []
-        args = make_args(uuid="nonexistent-uuid", url=None, username=None, password=None, title=None)
+        mock_client.get_logins.return_value = []
+        args = make_args(uuid="nonexistent-uuid", url="https://example.com", username=None, password=None, title=None)
         rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
         assert "not found" in capsys.readouterr().err.lower()
@@ -215,16 +214,26 @@ class TestRmCommand:
 # --- totp ---
 
 class TestTotpCommand:
-    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry()
+        mock_client.get_logins.return_value = [entry]
         mock_client.get_totp.return_value = "654321"
-        args = make_args(uuid="some-uuid")
+        args = make_args(url="https://example.com")
         rc = totp.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         assert "654321" in capsys.readouterr().out
 
-    def test_no_totp(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+    def test_no_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_logins.return_value = []
+        args = make_args(url="https://example.com")
+        rc = totp.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+    def test_no_totp(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry()
+        mock_client.get_logins.return_value = [entry]
         mock_client.get_totp.return_value = None
-        args = make_args(uuid="some-uuid")
+        args = make_args(url="https://example.com")
         rc = totp.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -59,14 +59,6 @@ class TestPrintEntries:
         data = json.loads(out)
         assert data[0]["password"] == "s3cr3t"
 
-    def test_tsv_format(self, capsys, sample_entry):
-        print_entries([sample_entry], fmt="tsv")
-        out = capsys.readouterr().out
-        lines = out.strip().split("\n")
-        assert lines[0] == "UUID\tTitle\tUsername\tURL\tGroup"
-        assert "GitHub" in lines[1]
-        assert "user@example.com" in lines[1]
-
     def test_table_format_multiple_entries(self, capsys, sample_entry):
         entries = [sample_entry, sample_entry]
         print_entries(entries, fmt="table")
@@ -87,13 +79,6 @@ class TestPrintGroups:
         data = json.loads(out)
         assert data[0]["name"] == "Root"
         assert data[0]["children"][0]["name"] == "Personal"
-
-    def test_tsv_format(self, capsys, sample_group):
-        # flat_list must work; the Group dataclass has flat_list method
-        print_groups([sample_group], fmt="tsv")
-        out = capsys.readouterr().out
-        lines = out.strip().split("\n")
-        assert lines[0] == "UUID\tName"
 
 
 class TestPrintEntryDetail:
@@ -116,11 +101,6 @@ class TestPrintEntryDetail:
         assert data["name"] == "GitHub"
         assert data["password"] == "s3cr3t"
 
-    def test_tsv_format(self, capsys, sample_entry):
-        print_entry_detail(sample_entry, fmt="tsv")
-        out = capsys.readouterr().out
-        assert "Title\tGitHub" in out
-
 
 class TestPrintTotp:
     def test_table_format(self, capsys):
@@ -131,10 +111,6 @@ class TestPrintTotp:
         print_totp("123456", fmt="json")
         data = json.loads(capsys.readouterr().out)
         assert data["totp"] == "123456"
-
-    def test_tsv_format(self, capsys):
-        print_totp("123456", fmt="tsv")
-        assert "TOTP\t123456" in capsys.readouterr().out
 
 
 class TestPrintPassword:


### PR DESCRIPTION
## Changes

### `-j/--json` flag replaces `--format {table,json,tsv}`

The old global `--format` had to be placed **before** the subcommand name, which broke `keepassxc-cli show url --format json`. The new `-j/--json` flag is added to each subparser via `argparse.parents`, so it can appear **anywhere after the subcommand**.

```sh
keepassxc-cli show https://github.com -j
keepassxc-cli show -j https://github.com   # also works
keepassxc-cli ls -j
```

TSV output removed (was never exposed in docs and added noise).

### TOTP hidden unless `-p`

`show` no longer prints the TOTP field by default. Pass `-p/--show-password` to reveal both password and TOTP.

### `search` — uses `get-logins` instead of `get-database-entries`

`get-database-entries` requires *"Allow access to all entries"* to be enabled in KeePassXC, which most users haven't done and which was returning an error. `search` now calls `get_logins(query)`, matching by URL/hostname (the same mechanism the browser extension uses).

### `totp` — accepts URL instead of UUID

```sh
# before
keepassxc-cli totp 5eb37d426e1afb3076d327ed3ca7cb27

# after
keepassxc-cli totp https://github.com
```

The entry is resolved via `get_logins` and the UUID is passed to `get_totp` internally — consistent with `show` and `clip`.

### `clip` — `field` is now a positional argument

```sh
# before
keepassxc-cli clip --field totp https://github.com

# after
keepassxc-cli clip totp https://github.com
keepassxc-cli clip password https://github.com
keepassxc-cli clip username https://github.com
```

### Bump `keepassxc-browser-api` to `==0.1.3`

Requires the companion browser-api fix for `generate_password` and `get_database_entries`.