### PR TITLE
chore: remove stubs for unused API methods from test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,11 +70,8 @@ def mock_client():
     client.test_associate.return_value = True
     client.get_logins.return_value = [make_entry()]
     client.set_login.return_value = True
-    client.get_database_entries.return_value = [make_entry()]
-    client.get_database_groups.return_value = [make_group()]
     client.create_group.return_value = make_group(uuid="new-uuid", name="NewGroup")
     client.get_totp.return_value = "123456"
     client.delete_entry.return_value = True
     client.lock_database.return_value = True
-    client.generate_password.return_value = "GeneratedPass123"
     return client

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from keepassxc_browser_api import Entry, Group, BrowserConfig, Association
+from keepassxc_browser_api import Entry, BrowserConfig, Association
 from keepassxc_cli.config import CliConfig
 from keepassxc_cli.commands import (
     setup, status, show, add, edit, rm, totp, clip, lock, mkdir,


### PR DESCRIPTION
Remove `mock_client` stubs for `get_database_entries`, `get_database_groups`, `generate_password` — these methods were removed from `keepassxc-browser-api`. Remove unused `Group` import from `test_commands.py`.