### PR TITLE
feat: strip KPH: prefix from string field names by default

### DIFF
--- a/keepassxc_cli/commands/show.py
+++ b/keepassxc_cli/commands/show.py
@@ -15,6 +15,7 @@ def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.Argu
     p = subparsers.add_parser("show", parents=parents, help="Show entries matching a URL")
     p.add_argument("url", help="URL or search string")
     p.add_argument("-p", "--show-password", action="store_true", help="Reveal password and TOTP")
+    p.add_argument("--show-kph-prefix", action="store_true", help="Keep 'KPH: ' prefix on custom string field names")
     p.set_defaults(func=run)
 
 
@@ -32,7 +33,7 @@ def run(
         print(f"No entries found for: {args.url}", file=sys.stderr)
         return 1
     for entry in entries:
-        print_entry_detail(entry, fmt, show_password=args.show_password)
+        print_entry_detail(entry, fmt, show_password=args.show_password, show_kph_prefix=getattr(args, "show_kph_prefix", False))
         if fmt == "table" and len(entries) > 1:
             print()
     return 0

--- a/keepassxc_cli/output.py
+++ b/keepassxc_cli/output.py
@@ -4,9 +4,26 @@ import json
 
 from keepassxc_browser_api import Entry
 
+_KPH_PREFIX = "KPH: "
 
-def print_entry_detail(entry: Entry, fmt: str = "table", show_password: bool = False) -> None:
+
+def _strip_kph(key: str) -> str:
+    return key[len(_KPH_PREFIX):] if key.startswith(_KPH_PREFIX) else key
+
+
+def print_entry_detail(
+    entry: Entry,
+    fmt: str = "table",
+    show_password: bool = False,
+    show_kph_prefix: bool = False,
+) -> None:
     totp = entry.totp if show_password else None
+
+    def _fields() -> list[dict[str, str]]:
+        if show_kph_prefix:
+            return entry.string_fields
+        return [{_strip_kph(k): v for k, v in sf.items()} for sf in entry.string_fields]
+
     if fmt == "json":
         data = {
             "uuid": entry.uuid,
@@ -14,7 +31,7 @@ def print_entry_detail(entry: Entry, fmt: str = "table", show_password: bool = F
             "login": entry.login,
             "group": entry.group,
             "group_uuid": entry.group_uuid,
-            "string_fields": entry.string_fields,
+            "string_fields": _fields(),
         }
         if show_password:
             data["password"] = entry.password
@@ -35,7 +52,7 @@ def print_entry_detail(entry: Entry, fmt: str = "table", show_password: bool = F
     if entry.group_uuid:
         print(f"Group UUID: {entry.group_uuid}")
     if entry.string_fields:
-        for sf in entry.string_fields:
+        for sf in _fields():
             for k, v in sf.items():
                 print(f"{k}: {v}")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -32,6 +32,7 @@ def browser_config_path(tmp_path):
 def make_args(**kwargs) -> argparse.Namespace:
     defaults = {
         "show_password": False,
+        "show_kph_prefix": False,
         "yes": False,
         "field": "password",
         "url": "https://example.com",
@@ -99,7 +100,7 @@ class TestStatusCommand:
 
 class TestShowCommand:
     def test_found_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
-        entry = mock_entry()
+        entry = mock_entry(string_fields=[{"KPH: url": "https://github.com"}])
         mock_client.get_logins.return_value = [entry]
         args = make_args(url="https://example.com", show_password=False)
         rc = show.run(mock_client, args, cli_config, browser_config, browser_config_path)
@@ -107,6 +108,8 @@ class TestShowCommand:
         out = capsys.readouterr().out
         assert "Test Entry" in out
         assert "Password" not in out
+        assert "KPH: " not in out
+        assert "url: https://github.com" in out
 
     def test_found_entries_show_password(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
         entry = mock_entry()
@@ -117,6 +120,14 @@ class TestShowCommand:
         out = capsys.readouterr().out
         assert "Test Entry" in out
         assert "Password:" in out
+
+    def test_found_entries_show_kph_prefix(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry(string_fields=[{"KPH: url": "https://github.com"}])
+        mock_client.get_logins.return_value = [entry]
+        args = make_args(url="https://example.com", show_password=False, show_kph_prefix=True)
+        rc = show.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "KPH: url: https://github.com" in capsys.readouterr().out
 
     def test_no_entries(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.get_logins.return_value = []

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -34,12 +34,20 @@ class TestPrintEntryDetail:
         assert "user@example.com" in out
         assert "Password" not in out
         assert "s3cr3t" not in out
+        assert "KPH: " not in out
+        assert "url: https://github.com" in out
 
     def test_table_format_show_password(self, capsys, sample_entry):
         print_entry_detail(sample_entry, fmt="table", show_password=True)
         out = capsys.readouterr().out
         assert "s3cr3t" in out
         assert "Password:" in out
+        assert "KPH: " not in out
+
+    def test_table_format_show_kph_prefix(self, capsys, sample_entry):
+        print_entry_detail(sample_entry, fmt="table", show_password=False, show_kph_prefix=True)
+        out = capsys.readouterr().out
+        assert "KPH: url: https://github.com" in out
 
     def test_json_format_hidden(self, capsys, sample_entry):
         print_entry_detail(sample_entry, fmt="json", show_password=False)
@@ -47,6 +55,7 @@ class TestPrintEntryDetail:
         data = json.loads(out)
         assert data["name"] == "GitHub"
         assert "password" not in data
+        assert data["string_fields"] == [{"url": "https://github.com"}]
 
     def test_json_format_show_password(self, capsys, sample_entry):
         print_entry_detail(sample_entry, fmt="json", show_password=True)
@@ -54,6 +63,12 @@ class TestPrintEntryDetail:
         data = json.loads(out)
         assert data["name"] == "GitHub"
         assert data["password"] == "s3cr3t"
+        assert data["string_fields"] == [{"url": "https://github.com"}]
+
+    def test_json_format_show_kph_prefix(self, capsys, sample_entry):
+        print_entry_detail(sample_entry, fmt="json", show_password=False, show_kph_prefix=True)
+        data = json.loads(capsys.readouterr().out)
+        assert data["string_fields"] == [{"KPH: url": "https://github.com"}]
 
 
 class TestPrintTotp:


### PR DESCRIPTION
KeePassXC prefixes custom string field names with `KPH: ` internally. This strips the prefix from output by default in both table and JSON mode, and adds `--show-kph-prefix` to `show` to opt back in to the raw names.