### PR TITLE
fix: remove unsupported --title option from add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,14 @@ keepassxc-cli clip totp     https://github.com
 #### `add` — Add a new entry
 
 ```bash
-keepassxc-cli add --url https://example.com --username user@example.com --title "Example"
 # Password is prompted securely if --password is not given
+keepassxc-cli add --url https://example.com --username user@example.com
 keepassxc-cli add --url https://example.com --username user --password mypass
+# Place the entry in a specific group by UUID
+keepassxc-cli add --url https://example.com --username user --group-uuid <group-uuid>
 ```
+
+> **Note**: The entry title is always derived from the URL hostname by KeePassXC. The protocol has no field to set a custom title.
 
 #### `edit` — Edit an entry
 

--- a/keepassxc_cli/commands/add.py
+++ b/keepassxc_cli/commands/add.py
@@ -15,7 +15,6 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--url", required=True, help="Entry URL")
     p.add_argument("--username", required=True, help="Username")
     p.add_argument("--password", default=None, help="Password (prompted if omitted)")
-    p.add_argument("--title", default="", help="Entry title")
     p.add_argument("--group-uuid", default="", help="Target group UUID")
     p.set_defaults(func=run)
 
@@ -37,7 +36,6 @@ def run(
         url=args.url,
         username=args.username,
         password=password,
-        title=args.title,
         group_uuid=args.group_uuid,
     )
     if success:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==1.0.0",
+    "keepassxc-browser-api==1.1.0",
     "pyperclip==1.8.0",
 ]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -38,7 +38,6 @@ def make_args(**kwargs) -> argparse.Namespace:
         "url": "https://example.com",
         "username": "user",
         "password": "pass",
-        "title": "Example",
         "group_uuid": "",
         "uuid": "abcdef12-0000-0000-0000-000000000000",
         "name": "NewGroup",
@@ -142,7 +141,7 @@ class TestShowCommand:
 class TestAddCommand:
     def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.set_login.return_value = True
-        args = make_args(url="https://example.com", username="u", password="p", title="T", group_uuid="")
+        args = make_args(url="https://example.com", username="u", password="p", group_uuid="")
         rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         mock_client.set_login.assert_called_once()
@@ -150,7 +149,7 @@ class TestAddCommand:
 
     def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.set_login.return_value = False
-        args = make_args(url="https://example.com", username="u", password="p", title="T", group_uuid="")
+        args = make_args(url="https://example.com", username="u", password="p", group_uuid="")
         rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
 


### PR DESCRIPTION
The `set-login` protocol does not support a custom entry title. `BrowserService::addEntry()` always derives the entry title from the URL hostname — `entryParameters.title` is never populated from the request. The `--title` argument is removed from the `add` command.

Also bumps `keepassxc-browser-api` to 1.1.0, which removes `title` from `set_login()` and fixes `group_uuid` being silently ignored (see mietzen/keepassxc-browser-api#7).

Fixes #8