### PR TITLE
fix: replace --parent-uuid with path syntax for mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ keepassxc-cli lock
 
 ```bash
 keepassxc-cli mkdir "Work"
-keepassxc-cli mkdir "Projects" --parent-uuid <parent-group-uuid>
+keepassxc-cli mkdir "Work/Projects"   # create Projects inside Work
 ```
+
+Use `/`-separated paths to create nested groups. KeePassXC creates any missing path segments automatically.
 
 ## Configuration
 

--- a/keepassxc_cli/commands/mkdir.py
+++ b/keepassxc_cli/commands/mkdir.py
@@ -11,8 +11,10 @@ from keepassxc_cli.config import CliConfig
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser("mkdir", help="Create a new group")
-    p.add_argument("name", help="Group name")
-    p.add_argument("--parent-uuid", default="", help="Parent group UUID")
+    p.add_argument(
+        "name",
+        help="Group name or path. Use '/' to create nested groups (e.g. 'Work/Projects').",
+    )
     p.set_defaults(func=run)
 
 
@@ -25,7 +27,7 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    group = client.create_group(args.name, parent_group_uuid=args.parent_uuid)
+    group = client.create_group(args.name)
     if group is None:
         print("Failed to create group.", file=sys.stderr)
         return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==1.0.0",
+    "keepassxc-browser-api==1.1.0",
     "pyperclip==1.8.0",
 ]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -42,7 +42,6 @@ def make_args(**kwargs) -> argparse.Namespace:
         "group_uuid": "",
         "uuid": "abcdef12-0000-0000-0000-000000000000",
         "name": "NewGroup",
-        "parent_uuid": "",
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -270,14 +269,22 @@ class TestMkdirCommand:
     def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
         new_group = mock_group(uuid="new-uuid", name="MyGroup")
         mock_client.create_group.return_value = new_group
-        args = make_args(name="MyGroup", parent_uuid="")
+        args = make_args(name="MyGroup")
         rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         out = capsys.readouterr().out
         assert "MyGroup" in out
 
+    def test_path_syntax(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        new_group = mock_group(uuid="new-uuid", name="Projects")
+        mock_client.create_group.return_value = new_group
+        args = make_args(name="Work/Projects")
+        rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.create_group.assert_called_once_with("Work/Projects")
+
     def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.create_group.return_value = None
-        args = make_args(name="MyGroup", parent_uuid="")
+        args = make_args(name="MyGroup")
         rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1


### PR DESCRIPTION
KeePassXC 2.7.9 `handleCreateNewGroup()` reads only `groupName` from the request — there is no parent UUID field. `BrowserService::createNewGroup()` splits `groupName` on `/` to build nested groups.

The `--parent-uuid` option is removed. Use path syntax in the `name` argument instead:

```bash
keepassxc-cli mkdir "Work/Projects"   # creates Projects inside Work
```

Also bumps `keepassxc-browser-api` to 1.1.0, which removes the broken `parent_group_uuid`/`groupUuid` from `create_group()` and fixes `group_uuid` being silently ignored in `set_login()` (see mietzen/keepassxc-browser-api#7).

Fixes #9