### PR TITLE
feat: add group-uuid and version commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,33 @@ keepassxc-cli mkdir "Work/Projects"   # create Projects inside Work
 
 Use `/`-separated paths to create nested groups. KeePassXC creates any missing path segments automatically.
 
+#### `group-uuid` — Look up a group's UUID by path
+
+```bash
+keepassxc-cli group-uuid "Work"
+keepassxc-cli group-uuid "Work/Projects"
+keepassxc-cli group-uuid "Work/Projects" -j
+```
+
+Returns the UUID for the group at the given path (relative to the database root). Useful for scripting — pipe the UUID into `add --group-uuid`.
+
+JSON output (`-j`):
+```json
+{
+  "path": "Work/Projects",
+  "name": "Projects",
+  "uuid": "<uuid>"
+}
+```
+
+#### `version` — Show the CLI version
+
+```bash
+keepassxc-cli version
+```
+
+Does not require a running KeePassXC instance.
+
 ## Configuration
 
 ### CLI config (`~/.keepassxc/cli.json`)

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ keepassxc-cli lock
 
 ```bash
 keepassxc-cli mkdir "Work"
-keepassxc-cli mkdir "Projects" --parent-uuid <parent-group-uuid>
+keepassxc-cli mkdir "Work/Projects"   # create Projects inside Work
 ```
+
+Use `/`-separated paths to create nested groups. KeePassXC creates any missing path segments automatically.
 
 ## Configuration
 

--- a/keepassxc_cli/__main__.py
+++ b/keepassxc_cli/__main__.py
@@ -11,7 +11,7 @@ from keepassxc_browser_api import BrowserClient, BrowserConfig
 from keepassxc_browser_api.exceptions import KeePassXCError, ConnectionError
 
 from .config import CliConfig, DEFAULT_CLI_CONFIG_PATH
-from .commands import setup, status, show, add, edit, rm, totp, clip, lock, mkdir
+from .commands import setup, status, show, add, edit, rm, totp, clip, lock, mkdir, group_uuid, version
 
 # Shared parent parser that injects -j/--json into each subparser that supports it.
 # Defined at module level so command modules can import it if needed.
@@ -55,6 +55,8 @@ def main() -> None:
     clip.add_parser(subparsers)
     lock.add_parser(subparsers)
     mkdir.add_parser(subparsers)
+    group_uuid.add_parser(subparsers, fmt_parent)
+    version.add_parser(subparsers)
 
     args = parser.parse_args()
 

--- a/keepassxc_cli/commands/group_uuid.py
+++ b/keepassxc_cli/commands/group_uuid.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
+    parents = [fmt_parent] if fmt_parent else []
+    p = subparsers.add_parser(
+        "group-uuid",
+        parents=parents,
+        help="Look up the UUID of a group by its path",
+    )
+    p.add_argument(
+        "path",
+        help="Group path relative to the database root (e.g. 'Work/Projects')",
+    )
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    groups = client.get_database_groups()
+    if not groups:
+        print("Failed to retrieve group tree.", file=sys.stderr)
+        return 1
+
+    root = groups[0]
+    parts = args.path.split("/")
+
+    # Paths are root-relative: traverse root.children, not the root itself.
+    current = root.children
+    matched = None
+    for part in parts:
+        matched = next((g for g in current if g.name == part), None)
+        if matched is None:
+            print(f"Group not found: {args.path!r}", file=sys.stderr)
+            return 1
+        current = matched.children
+
+    if fmt == "json":
+        print(json.dumps({"path": args.path, "name": matched.name, "uuid": matched.uuid}, indent=2))
+    else:
+        print(f"{args.path} [{matched.uuid}]")
+    return 0

--- a/keepassxc_cli/commands/mkdir.py
+++ b/keepassxc_cli/commands/mkdir.py
@@ -11,8 +11,10 @@ from keepassxc_cli.config import CliConfig
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser("mkdir", help="Create a new group")
-    p.add_argument("name", help="Group name")
-    p.add_argument("--parent-uuid", default="", help="Parent group UUID")
+    p.add_argument(
+        "name",
+        help="Group name or path. Use '/' to create nested groups (e.g. 'Work/Projects').",
+    )
     p.set_defaults(func=run)
 
 
@@ -25,7 +27,7 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    group = client.create_group(args.name, parent_group_uuid=args.parent_uuid)
+    group = client.create_group(args.name)
     if group is None:
         print("Failed to create group.", file=sys.stderr)
         return 1

--- a/keepassxc_cli/commands/version.py
+++ b/keepassxc_cli/commands/version.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from keepassxc_browser_api import BrowserClient, BrowserConfig
+
+from keepassxc_cli.config import CliConfig
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("version", help="Show the keepassxc-cli version")
+    p.set_defaults(func=run)
+
+
+def run(
+    client: BrowserClient,
+    args: argparse.Namespace,
+    cli_config: CliConfig,
+    browser_config: BrowserConfig,
+    browser_config_path: Path,
+    *,
+    fmt: str = "table",
+) -> int:
+    try:
+        ver = version("keepassxc-cli")
+    except PackageNotFoundError:
+        ver = "unknown"
+    print(f"keepassxc-cli {ver}")
+    return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==1.0.0",
+    "keepassxc-browser-api==1.1.0",
     "pyperclip==1.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
-    "keepassxc-browser-api==1.1.0",
+    "keepassxc-browser-api==1.2.0",
     "pyperclip==1.8.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ def mock_client():
     client.get_logins.return_value = [make_entry()]
     client.set_login.return_value = True
     client.create_group.return_value = make_group(uuid="new-uuid", name="NewGroup")
+    client.get_database_groups.return_value = [make_group()]
     client.get_totp.return_value = "123456"
     client.delete_entry.return_value = True
     client.lock_database.return_value = True

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -42,7 +42,6 @@ def make_args(**kwargs) -> argparse.Namespace:
         "group_uuid": "",
         "uuid": "abcdef12-0000-0000-0000-000000000000",
         "name": "NewGroup",
-        "parent_uuid": "",
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -270,14 +269,22 @@ class TestMkdirCommand:
     def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
         new_group = mock_group(uuid="new-uuid", name="MyGroup")
         mock_client.create_group.return_value = new_group
-        args = make_args(name="MyGroup", parent_uuid="")
+        args = make_args(name="MyGroup")
         rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         out = capsys.readouterr().out
         assert "MyGroup" in out
 
+    def test_path_syntax(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        new_group = mock_group(uuid="new-uuid", name="Projects")
+        mock_client.create_group.return_value = new_group
+        args = make_args(name="Work/Projects")
+        rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.create_group.assert_called_once_with("Work/Projects")
+
     def test_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.create_group.return_value = None
-        args = make_args(name="MyGroup", parent_uuid="")
+        args = make_args(name="MyGroup")
         rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -10,7 +10,7 @@ import pytest
 from keepassxc_browser_api import Entry, BrowserConfig, Association
 from keepassxc_cli.config import CliConfig
 from keepassxc_cli.commands import (
-    setup, status, show, add, edit, rm, totp, clip, lock, mkdir,
+    setup, status, show, add, edit, rm, totp, clip, lock, mkdir, group_uuid, version,
 )
 
 
@@ -42,6 +42,7 @@ def make_args(**kwargs) -> argparse.Namespace:
         "group_uuid": "",
         "uuid": "abcdef12-0000-0000-0000-000000000000",
         "name": "NewGroup",
+        "path": "Work",
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -288,3 +289,86 @@ class TestMkdirCommand:
         args = make_args(name="MyGroup")
         rc = mkdir.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
+
+
+# --- group-uuid ---
+
+
+class TestGroupUuidCommand:
+    def _make_tree(self, mock_group):
+        from keepassxc_browser_api import Group
+        projects = mock_group(uuid="projects-uuid", name="Projects")
+        work = mock_group(uuid="work-uuid", name="Work", children=[projects])
+        root = mock_group(uuid="root-uuid", name="Root", children=[work])
+        return [root]
+
+    def test_found_top_level(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        mock_client.get_database_groups.return_value = self._make_tree(mock_group)
+        args = make_args(path="Work")
+        rc = group_uuid.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "work-uuid" in out
+        assert "Work" in out
+
+    def test_found_nested_path(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        mock_client.get_database_groups.return_value = self._make_tree(mock_group)
+        args = make_args(path="Work/Projects")
+        rc = group_uuid.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "projects-uuid" in out
+
+    def test_not_found(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        mock_client.get_database_groups.return_value = self._make_tree(mock_group)
+        args = make_args(path="Nonexistent")
+        rc = group_uuid.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not found" in err.lower()
+
+    def test_not_found_mid_path(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        mock_client.get_database_groups.return_value = self._make_tree(mock_group)
+        args = make_args(path="Work/Nope/Projects")
+        rc = group_uuid.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+    def test_json_output(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        import json
+        mock_client.get_database_groups.return_value = self._make_tree(mock_group)
+        args = make_args(path="Work/Projects")
+        rc = group_uuid.run(mock_client, args, cli_config, browser_config, browser_config_path, fmt="json")
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["path"] == "Work/Projects"
+        assert data["name"] == "Projects"
+        assert data["uuid"] == "projects-uuid"
+
+    def test_get_database_groups_failure(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.get_database_groups.return_value = []
+        args = make_args(path="Work")
+        rc = group_uuid.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+
+
+# --- version ---
+
+
+class TestVersionCommand:
+    def test_prints_version(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        with patch("keepassxc_cli.commands.version.version", return_value="1.3.0"):
+            args = make_args()
+            rc = version.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "keepassxc-cli" in out
+        assert "1.3.0" in out
+
+    def test_package_not_found(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        from importlib.metadata import PackageNotFoundError
+        with patch("keepassxc_cli.commands.version.version", side_effect=PackageNotFoundError):
+            args = make_args()
+            rc = version.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "unknown" in out


### PR DESCRIPTION
Adds two new commands:

### `group-uuid <path>`
Looks up the UUID of a group by its path (e.g. `Work/Projects`). Traverses the group tree returned by the new `get_database_groups()` API (keepassxc-browser-api v1.2.0).

Supports `-j/--json` output:
```json
{"path": "Work/Projects", "name": "Projects", "uuid": "<uuid>"}
```

### `version`
Prints `keepassxc-cli <version>`. Does not require a running KeePassXC instance.

---

**Dependency**: Bumps `keepassxc-browser-api` to `==1.2.0` (released).

Closes mietzen/keepassxc-browser-api#8 (prerequisite — already merged)