### PR TITLE
feat: improve UX for edit, rm, and add commands

### DIFF
--- a/keepassxc_cli/commands/add.py
+++ b/keepassxc_cli/commands/add.py
@@ -17,7 +17,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--url", required=True, help="Entry URL")
     p.add_argument("--username", required=True, help="Username")
     p.add_argument("--password", default=None, help="Password (prompted if omitted)")
-    p.add_argument("--group-uuid", default="", help="Target group UUID")
+    group = p.add_mutually_exclusive_group()
+    group.add_argument("--group-uuid", default="", help="Target group UUID")
+    group.add_argument("--group", default=None, help="Target group path (e.g. 'Work/Projects')")
     p.set_defaults(func=run)
 
 
@@ -34,11 +36,27 @@ def run(
     if password is None:
         password = getpass.getpass("Password: ")
 
+    group_uuid = args.group_uuid
+
+    if args.group is not None:
+        groups = client.get_database_groups()
+        root = groups[0]
+        parts = args.group.split("/")
+        current = root.children
+        matched = None
+        for part in parts:
+            matched = next((g for g in current if g.name == part), None)
+            if matched is None:
+                logger.error("Group not found: %r", args.group)
+                return 1
+            current = matched.children
+        group_uuid = matched.uuid
+
     client.set_login(
         url=args.url,
         username=args.username,
         password=password,
-        group_uuid=args.group_uuid,
+        group_uuid=group_uuid,
     )
     print("Entry added successfully.")
     return 0

--- a/keepassxc_cli/commands/edit.py
+++ b/keepassxc_cli/commands/edit.py
@@ -14,17 +14,16 @@ logger = logging.getLogger(__name__)
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser(
         "edit",
-        help="Edit an existing entry by UUID",
+        help="Edit an existing entry",
         description=(
-            "Edit an existing entry. The UUID must be known (use 'show' to find it).\n"
-            "Provide --url so the entry can be resolved; omitted fields are left unchanged."
+            "Edit an existing entry. Provide --url to look up the entry; omitted fields are\n"
+            "left unchanged. If the URL matches multiple entries, specify --uuid to disambiguate."
         ),
     )
-    p.add_argument("uuid", help="UUID of the entry to edit")
-    p.add_argument("--url", required=True, help="URL of the entry (used to resolve current values)")
+    p.add_argument("--url", required=True, help="URL of the entry")
+    p.add_argument("--uuid", default=None, help="UUID of the entry (required when URL matches multiple entries)")
     p.add_argument("--username", default=None, help="New username")
     p.add_argument("--password", default=None, help="New password")
-    p.add_argument("--title", default=None, help="New title")
     p.set_defaults(func=run)
 
 
@@ -37,21 +36,35 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    # Resolve current entry values via get_logins (no special permission needed)
     entries = client.get_logins(args.url)
-    entry = next((e for e in entries if e.uuid == args.uuid), None)
-    if entry is None:
+
+    if not entries:
+        logger.error("No entries found for: %s", args.url)
+        return 1
+
+    if args.uuid is not None:
+        entry = next((e for e in entries if e.uuid == args.uuid), None)
+        if entry is None:
+            logger.error(
+                "Entry %s not found for URL: %s",
+                args.uuid, args.url,
+            )
+            return 1
+    elif len(entries) == 1:
+        entry = entries[0]
+    else:
         logger.error(
-            "Entry %s not found for URL: %s\nHint: use 'keepassxc-cli show <url>' to look up the UUID.",
-            args.uuid, args.url,
+            "Multiple entries found for %s — specify --uuid to disambiguate:",
+            args.url,
         )
+        for e in entries:
+            print(f"  {e.uuid}  {e.login}  ({e.name})")
         return 1
 
     client.set_login(
         url=args.url,
         username=args.username if args.username is not None else entry.login,
         password=args.password if args.password is not None else entry.password,
-        title=args.title if args.title is not None else entry.name,
         uuid=entry.uuid,
         group_uuid=entry.group_uuid,
     )

--- a/keepassxc_cli/commands/rm.py
+++ b/keepassxc_cli/commands/rm.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
-    p = subparsers.add_parser("rm", help="Delete an entry by UUID")
-    p.add_argument("uuid", help="UUID of the entry to delete")
+    p = subparsers.add_parser("rm", help="Delete an entry")
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument("--uuid", default=None, help="UUID of the entry to delete")
+    group.add_argument("--url", default=None, help="URL of the entry to delete (must match exactly one entry)")
     p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
     p.set_defaults(func=run)
 
@@ -27,12 +29,31 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
+    if args.uuid is not None:
+        target_uuid = args.uuid
+        label = args.uuid
+    else:
+        entries = client.get_logins(args.url)
+        if not entries:
+            logger.error("No entries found for: %s", args.url)
+            return 1
+        if len(entries) > 1:
+            logger.error(
+                "Multiple entries found for %s \u2014 specify --uuid to disambiguate:",
+                args.url,
+            )
+            for e in entries:
+                print(f"  {e.uuid}  {e.login}  ({e.name})")
+            return 1
+        target_uuid = entries[0].uuid
+        label = f"{entries[0].name} ({args.url})"
+
     if not args.yes:
-        answer = input(f"Delete entry {args.uuid}? [y/N] ").strip().lower()
+        answer = input(f"Delete entry {label}? [y/N] ").strip().lower()
         if answer != "y":
             print("Aborted.")
             return 1
 
-    client.delete_entry(args.uuid)
+    client.delete_entry(target_uuid)
     print("Entry deleted.")
     return 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,6 +40,7 @@ def make_args(**kwargs) -> argparse.Namespace:
         "username": "user",
         "password": "pass",
         "group_uuid": "",
+        "group": None,
         "uuid": "abcdef12-0000-0000-0000-000000000000",
         "name": "NewGroup",
         "path": "Work",
@@ -141,15 +142,36 @@ class TestShowCommand:
 class TestAddCommand:
     def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.set_login.return_value = True
-        args = make_args(url="https://example.com", username="u", password="p", group_uuid="")
+        args = make_args(url="https://example.com", username="u", password="p", group_uuid="", group=None)
         rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         mock_client.set_login.assert_called_once()
         assert "added" in capsys.readouterr().out.lower()
 
+    def test_group_path_resolved(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_group):
+        from keepassxc_browser_api import Group
+        projects = mock_group(uuid="proj-uuid", name="Projects")
+        work = mock_group(uuid="work-uuid", name="Work", children=[projects])
+        root = mock_group(uuid="root-uuid", name="Root", children=[work])
+        mock_client.get_database_groups.return_value = [root]
+        mock_client.set_login.return_value = True
+        args = make_args(url="https://example.com", username="u", password="p", group_uuid="", group="Work/Projects")
+        rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        call_kwargs = mock_client.set_login.call_args.kwargs
+        assert call_kwargs["group_uuid"] == "proj-uuid"
+
+    def test_group_path_not_found(self, mock_client, cli_config, browser_config, browser_config_path, caplog, mock_group):
+        root = mock_group(uuid="root-uuid", name="Root", children=[])
+        mock_client.get_database_groups.return_value = [root]
+        args = make_args(url="https://example.com", username="u", password="p", group_uuid="", group="NonExistent")
+        rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert any("not found" in r.message.lower() for r in caplog.records)
+
     def test_failure_propagates(self, mock_client, cli_config, browser_config, browser_config_path):
         mock_client.set_login.side_effect = ProtocolError("access denied", error_code=6)
-        args = make_args(url="https://example.com", username="u", password="p", group_uuid="")
+        args = make_args(url="https://example.com", username="u", password="p", group_uuid="", group=None)
         with pytest.raises(ProtocolError):
             add.run(mock_client, args, cli_config, browser_config, browser_config_path)
 
@@ -157,37 +179,91 @@ class TestAddCommand:
 # --- edit ---
 
 class TestEditCommand:
-    def test_entry_found_and_updated(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+    def test_uuid_specified_and_updated(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
         entry = mock_entry()
         mock_client.get_logins.return_value = [entry]
         mock_client.set_login.return_value = True
-        args = make_args(uuid=entry.uuid, url="https://example.com", username="newuser", password=None, title=None)
+        args = make_args(uuid=entry.uuid, url="https://example.com", username="newuser", password=None)
+        rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        assert "updated" in capsys.readouterr().out.lower()
+        mock_client.set_login.assert_called_once()
+        call_kwargs = mock_client.set_login.call_args.kwargs
+        assert "title" not in call_kwargs
+
+    def test_no_uuid_single_match_auto_selected(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry()
+        mock_client.get_logins.return_value = [entry]
+        mock_client.set_login.return_value = True
+        args = make_args(uuid=None, url="https://example.com", username="newuser", password=None)
         rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         assert "updated" in capsys.readouterr().out.lower()
 
-    def test_entry_not_found(self, mock_client, cli_config, browser_config, browser_config_path, caplog):
-        mock_client.get_logins.return_value = []
-        args = make_args(uuid="nonexistent-uuid", url="https://example.com", username=None, password=None, title=None)
+    def test_no_uuid_multiple_matches_error(self, mock_client, cli_config, browser_config, browser_config_path, caplog, mock_entry):
+        e1 = mock_entry(uuid="uuid-1", login="alice")
+        e2 = mock_entry(uuid="uuid-2", login="bob")
+        mock_client.get_logins.return_value = [e1, e2]
+        args = make_args(uuid=None, url="https://example.com", username="newuser", password=None)
+        rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert any("multiple" in r.message.lower() for r in caplog.records)
+
+    def test_uuid_not_in_results(self, mock_client, cli_config, browser_config, browser_config_path, caplog, mock_entry):
+        entry = mock_entry()
+        mock_client.get_logins.return_value = [entry]
+        args = make_args(uuid="nonexistent-uuid", url="https://example.com", username=None, password=None)
         rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
         assert any("not found" in r.message.lower() for r in caplog.records)
+
+    def test_no_entries_found(self, mock_client, cli_config, browser_config, browser_config_path, caplog):
+        mock_client.get_logins.return_value = []
+        args = make_args(uuid=None, url="https://example.com", username=None, password=None)
+        rc = edit.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert any("no entries" in r.message.lower() for r in caplog.records)
 
 
 # --- rm ---
 
 class TestRmCommand:
-    def test_with_yes_flag(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+    def test_uuid_with_yes_flag(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
         mock_client.delete_entry.return_value = True
-        args = make_args(uuid="some-uuid", yes=True)
+        args = make_args(uuid="some-uuid", url=None, yes=True)
         rc = rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 0
         mock_client.delete_entry.assert_called_once_with("some-uuid")
         assert "deleted" in capsys.readouterr().out.lower()
 
+    def test_url_single_match_deletes(self, mock_client, cli_config, browser_config, browser_config_path, capsys, mock_entry):
+        entry = mock_entry(uuid="url-resolved-uuid")
+        mock_client.get_logins.return_value = [entry]
+        mock_client.delete_entry.return_value = True
+        args = make_args(uuid=None, url="https://example.com", yes=True)
+        rc = rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.delete_entry.assert_called_once_with("url-resolved-uuid")
+
+    def test_url_multiple_matches_error(self, mock_client, cli_config, browser_config, browser_config_path, caplog, mock_entry):
+        e1 = mock_entry(uuid="uuid-1", login="alice")
+        e2 = mock_entry(uuid="uuid-2", login="bob")
+        mock_client.get_logins.return_value = [e1, e2]
+        args = make_args(uuid=None, url="https://example.com", yes=True)
+        rc = rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert any("multiple" in r.message.lower() for r in caplog.records)
+
+    def test_url_no_entries_error(self, mock_client, cli_config, browser_config, browser_config_path, caplog):
+        mock_client.get_logins.return_value = []
+        args = make_args(uuid=None, url="https://notfound.com", yes=True)
+        rc = rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 1
+        assert any("no entries" in r.message.lower() for r in caplog.records)
+
     def test_failure_propagates(self, mock_client, cli_config, browser_config, browser_config_path):
         mock_client.delete_entry.side_effect = ProtocolError("access denied", error_code=6)
-        args = make_args(uuid="some-uuid", yes=True)
+        args = make_args(uuid="some-uuid", url=None, yes=True)
         with pytest.raises(ProtocolError):
             rm.run(mock_client, args, cli_config, browser_config, browser_config_path)
 


### PR DESCRIPTION
## Changes

### `edit`
- `--uuid` is now an optional flag (was a required positional arg)
- `--url` stays required; auto-selects entry when URL matches exactly one entry
- Prints UUID/username/name list and errors when multiple entries match the URL
- Remove `--title` (not supported by the KeePassXC protocol — title is always derived from URL hostname)

### `rm`
- `--uuid` and `--url` are now a mutually exclusive group (one required)
- When `--url` given, resolves entry via the same single/multiple/none logic as `edit`
- Confirmation prompt shows entry name when resolved via URL

### `add`
- Add `--group "Work/Projects"` as alternative to `--group-uuid`
- Resolves group path via `get-database-groups` and passes the UUID to `set-login`
- `--group` and `--group-uuid` are mutually exclusive

8 new tests added (66 total).