### PR TITLE
feat: auto-prefix https:// for URLs without scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,19 +13,21 @@ keepassxc_cli/
 ├── __init__.py          # empty (just from __future__ import annotations)
 ├── __main__.py          # CLI entry point; argument parsing; dispatches to commands
 ├── config.py            # CliConfig dataclass; save/load ~/.keepassxc/cli.json
-├── output.py            # Output formatting: table, json
+├── output.py            # Output formatting: table, json; ensure_scheme() URL helper
 └── commands/
     ├── __init__.py      # empty
     ├── setup.py         # associate with KeePassXC
     ├── status.py        # show connection/association status
     ├── show.py          # show entries by URL
-    ├── add.py           # add new entry
-    ├── edit.py          # edit existing entry by UUID
-    ├── rm.py            # delete entry by UUID
+    ├── add.py           # add new entry (--group path or --group-uuid)
+    ├── edit.py          # edit existing entry by URL (--uuid optional)
+    ├── rm.py            # delete entry by UUID or URL
     ├── totp.py          # get TOTP code
     ├── clip.py          # copy field to clipboard
     ├── lock.py          # lock database
-    └── mkdir.py         # create group
+    ├── mkdir.py         # create group
+    ├── group_uuid.py    # look up a group UUID by path
+    └── version.py       # print installed package version
 
 tests/
 ├── conftest.py          # fixtures: mock_entry, mock_group, mock_browser_config, mock_client
@@ -109,6 +111,7 @@ ruff check --ignore=E501 --exclude=__init__.py ./keepassxc_cli
   | `4` | `ProtocolError(error_code=6 or 19)` — access denied by user |
 
 - **Config permissions**: Config files are written with `0o600` (owner read/write only).
+- **URL normalisation**: All URL-accepting command `run()` functions call `ensure_scheme(url)` (from `output.py`) before passing the URL to any `BrowserClient` method. This auto-prepends `https://` for bare hostnames (e.g. `example.com`) and emits a `logger.warning`. KeePassXC derives the entry title from `QUrl(url).host()`, which returns `""` for URLs without a scheme.
 - **Venv**: Always use `.venv` for development.
 - **Python ≥ 3.10** required.
 - **Password visibility**: `show` omits password and TOTP entirely when `-p` is not passed (no masking).

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ keepassxc-cli status -j
 
 ### Commands
 
+> **URL scheme**: All commands that accept a URL argument require a scheme (`https://` or `http://`). If you pass a bare hostname (e.g. `example.com`), the CLI will automatically prepend `https://` and emit a warning. KeePassXC derives the entry title from `QUrl(url).host()`, which returns an empty string for URLs without a scheme.
+
 #### `setup` — Associate with KeePassXC
 
 ```bash
@@ -115,8 +117,9 @@ keepassxc-cli clip totp     https://github.com
 # Password is prompted securely if --password is not given
 keepassxc-cli add --url https://example.com --username user@example.com
 keepassxc-cli add --url https://example.com --username user --password mypass
-# Place the entry in a specific group by UUID
+# Place the entry in a specific group by UUID or by path
 keepassxc-cli add --url https://example.com --username user --group-uuid <group-uuid>
+keepassxc-cli add --url https://example.com --username user --group "Work/Projects"
 ```
 
 > **Note**: The entry title is always derived from the URL hostname by KeePassXC. The protocol has no field to set a custom title.
@@ -124,19 +127,19 @@ keepassxc-cli add --url https://example.com --username user --group-uuid <group-
 #### `edit` — Edit an entry
 
 ```bash
-# Get the UUID first
-keepassxc-cli show https://github.com -p
-
-# Then edit — --url is required to resolve the current entry
-keepassxc-cli edit <uuid> --url https://github.com --username newuser
-keepassxc-cli edit <uuid> --url https://github.com --password newpass --title "New Title"
+# --url is required; --uuid is optional when the URL matches exactly one entry
+keepassxc-cli edit --url https://github.com --username newuser
+keepassxc-cli edit --url https://github.com --password newpass
+# Specify --uuid explicitly when the URL matches multiple entries
+keepassxc-cli edit --url https://github.com --uuid <uuid> --username newuser
 ```
 
 #### `rm` — Delete an entry
 
 ```bash
-keepassxc-cli rm <uuid>        # prompts for confirmation
-keepassxc-cli rm <uuid> --yes  # skip confirmation
+keepassxc-cli rm --uuid <uuid>        # prompts for confirmation
+keepassxc-cli rm --uuid <uuid> --yes  # skip confirmation
+keepassxc-cli rm --url https://example.com   # resolve by URL (errors if multiple matches)
 ```
 
 #### `lock` — Lock the database

--- a/keepassxc_cli/commands/add.py
+++ b/keepassxc_cli/commands/add.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import ensure_scheme
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
+    url = ensure_scheme(args.url)
     password = args.password
     if password is None:
         password = getpass.getpass("Password: ")
@@ -53,7 +55,7 @@ def run(
         group_uuid = matched.uuid
 
     client.set_login(
-        url=args.url,
+        url=url,
         username=args.username,
         password=password,
         group_uuid=group_uuid,

--- a/keepassxc_cli/commands/clip.py
+++ b/keepassxc_cli/commands/clip.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import ensure_scheme
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ def run(
         logger.error("pyperclip is required for clipboard support. Install it with: pip install pyperclip")
         return 1
 
-    entries = client.get_logins(args.url)
+    entries = client.get_logins(ensure_scheme(args.url))
     if not entries:
         logger.warning("No entries found for: %s", args.url)
         return 1

--- a/keepassxc_cli/commands/edit.py
+++ b/keepassxc_cli/commands/edit.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import ensure_scheme
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,8 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    entries = client.get_logins(args.url)
+    url = ensure_scheme(args.url)
+    entries = client.get_logins(url)
 
     if not entries:
         logger.error("No entries found for: %s", args.url)
@@ -62,7 +64,7 @@ def run(
         return 1
 
     client.set_login(
-        url=args.url,
+        url=url,
         username=args.username if args.username is not None else entry.login,
         password=args.password if args.password is not None else entry.password,
         uuid=entry.uuid,

--- a/keepassxc_cli/commands/rm.py
+++ b/keepassxc_cli/commands/rm.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import ensure_scheme
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ def run(
         target_uuid = args.uuid
         label = args.uuid
     else:
-        entries = client.get_logins(args.url)
+        entries = client.get_logins(ensure_scheme(args.url))
         if not entries:
             logger.error("No entries found for: %s", args.url)
             return 1

--- a/keepassxc_cli/commands/show.py
+++ b/keepassxc_cli/commands/show.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
-from keepassxc_cli.output import print_entry_detail
+from keepassxc_cli.output import ensure_scheme, print_entry_detail
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +30,10 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    entries = client.get_logins(args.url)
+    url = ensure_scheme(args.url)
+    entries = client.get_logins(url)
     if not entries:
-        logger.warning("No entries found for: %s", args.url)
+        logger.warning("No entries found for: %s", url)
         return 1
     for entry in entries:
         print_entry_detail(entry, fmt, show_password=args.show_password, show_kph_prefix=getattr(args, "show_kph_prefix", False))

--- a/keepassxc_cli/commands/totp.py
+++ b/keepassxc_cli/commands/totp.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
-from keepassxc_cli.output import print_totp
+from keepassxc_cli.output import ensure_scheme, print_totp
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    entries = client.get_logins(args.url)
+    entries = client.get_logins(ensure_scheme(args.url))
     if not entries:
         logger.warning("No entries found for: %s", args.url)
         return 1

--- a/keepassxc_cli/output.py
+++ b/keepassxc_cli/output.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 import json
+import logging
 
 from keepassxc_browser_api import Entry
 
 _KPH_PREFIX = "KPH: "
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_scheme(url: str) -> str:
+    """Return url with a scheme. Prepends https:// with a warning if none is present."""
+    if url.startswith("http://") or url.startswith("https://"):
+        return url
+    logger.warning("URL %r has no scheme, assuming https://", url)
+    return "https://" + url
 
 
 def _strip_kph(key: str) -> str:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -136,6 +136,15 @@ class TestShowCommand:
         assert rc == 1
         assert any("No entries" in r.message for r in caplog.records)
 
+    def test_url_no_scheme_prefixed(self, mock_client, cli_config, browser_config, browser_config_path, caplog, mock_entry):
+        entry = mock_entry()
+        mock_client.get_logins.return_value = [entry]
+        args = make_args(url="example.com", show_password=False)
+        rc = show.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.get_logins.assert_called_once_with("https://example.com")
+        assert any("no scheme" in r.message.lower() for r in caplog.records)
+
 
 # --- add ---
 
@@ -168,6 +177,15 @@ class TestAddCommand:
         rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
         assert rc == 1
         assert any("not found" in r.message.lower() for r in caplog.records)
+
+    def test_url_no_scheme_prefixed(self, mock_client, cli_config, browser_config, browser_config_path, caplog):
+        mock_client.set_login.return_value = True
+        args = make_args(url="example.com", username="u", password="p", group_uuid="", group=None)
+        rc = add.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        call_kwargs = mock_client.set_login.call_args.kwargs
+        assert call_kwargs["url"] == "https://example.com"
+        assert any("no scheme" in r.message.lower() for r in caplog.records)
 
     def test_failure_propagates(self, mock_client, cli_config, browser_config, browser_config_path):
         mock_client.set_login.side_effect = ProtocolError("access denied", error_code=6)


### PR DESCRIPTION
## Summary

All URL-accepting commands (`add`, `edit`, `rm`, `show`, `clip`, `totp`) now call `ensure_scheme()` (in `output.py`) before passing URLs to `BrowserClient`. Bare hostnames like `example.com` are automatically prefixed with `https://` and a warning is emitted to stderr.

## Root Cause

KeePassXC derives the entry title from `QUrl(url).host()` in C++. When no scheme is present, Qt treats the string as a relative path, so `QUrl("example.com").host()` returns `""`. This caused:
- Entries created with `add example.com` to have an empty title
- `show`/`edit`/`rm` URL lookups to fail silently

## Changes

- **`output.py`**: Add `ensure_scheme(url) -> str` helper + module-level logger
- **6 command files** (`add`, `edit`, `rm`, `show`, `clip`, `totp`): Call `ensure_scheme(args.url)` at start of `run()`
- **2 new tests**: `test_url_no_scheme_prefixed` in `TestShowCommand` and `TestAddCommand` (68 total)
- **README.md**: Correct `add`/`edit`/`rm` examples for v1.6.0 (positional uuid removed, `--title` gone, `--group` added); add URL scheme callout
- **CLAUDE.md**: Fix package structure (add `group_uuid.py`, `version.py`; update `edit.py`/`rm.py` comments); add URL normalisation convention