### PR TITLE
feat: v2.1.0 - unlock command, version -j, remove clip -j

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ keepassxc-cli clip https://github.com password
 keepassxc-cli clip https://github.com username
 keepassxc-cli clip https://github.com totp
 ```
+> **Note**: `clip` does not support `-j/--json` output — the field value is always copied silently to the clipboard.
 
 #### `add` — Add a new entry
 
@@ -147,7 +148,17 @@ keepassxc-cli rm https://example.com --uuid <uuid> --yes
 
 ```bash
 keepassxc-cli lock
+keepassxc-cli lock -j
 ```
+
+#### `unlock` — Unlock the database
+
+```bash
+keepassxc-cli unlock
+keepassxc-cli unlock -j
+```
+
+Triggers biometric (TouchID/fingerprint) unlock if configured. Raises an error if the unlock times out or KeePassXC is not running.
 
 #### `mkdir` — Create a group
 
@@ -181,6 +192,7 @@ JSON output (`-j`):
 
 ```bash
 keepassxc-cli version
+keepassxc-cli version -j
 ```
 
 Does not require a running KeePassXC instance.
@@ -256,6 +268,29 @@ pytest --cov=keepassxc_cli --cov-report=term-missing
 # Lint
 ruff check --ignore=E501 --exclude=__init__.py ./keepassxc_cli
 ```
+
+Verify with [manual tests](/tests/manual_test.md).
+
+---
+
+### Exit codes
+
+| Scenario | Expected code |
+|----------|---------------|
+| Any successful command | `0` |
+| Entry not found / generic error | `1` |
+| KeePassXC not running | `2` |
+| Unlock timed out | `3` |
+| Access denied by user | `4` |
+
+```bash
+keepassxc-cli show https://test.example.com; echo "exit: $?"    # 0
+keepassxc-cli show https://ghost.example.com; echo "exit: $?"   # 1
+# Quit KeePassXC, then:
+keepassxc-cli status; echo "exit: $?"                           # 2
+```
+
+---
 
 ## Known Limitations
 

--- a/keepassxc_cli/__main__.py
+++ b/keepassxc_cli/__main__.py
@@ -11,7 +11,7 @@ from keepassxc_browser_api import BrowserClient, BrowserConfig
 from keepassxc_browser_api.exceptions import ConnectionError, DatabaseLockedError, KeePassXCError, ProtocolError
 
 from .config import CliConfig, DEFAULT_CLI_CONFIG_PATH
-from .commands import setup, status, show, add, edit, rm, totp, clip, lock, mkdir, group_uuid, version
+from .commands import setup, status, show, add, edit, rm, totp, clip, lock, unlock, mkdir, group_uuid, version
 
 # Shared parent parser that injects -j/--json into each subparser that supports it.
 # Defined at module level so command modules can import it if needed.
@@ -52,11 +52,12 @@ def main() -> None:
     edit.add_parser(subparsers, fmt_parent)
     rm.add_parser(subparsers, fmt_parent)
     totp.add_parser(subparsers, fmt_parent)
-    clip.add_parser(subparsers, fmt_parent)
+    clip.add_parser(subparsers)
     lock.add_parser(subparsers, fmt_parent)
+    unlock.add_parser(subparsers, fmt_parent)
     mkdir.add_parser(subparsers, fmt_parent)
     group_uuid.add_parser(subparsers, fmt_parent)
-    version.add_parser(subparsers)
+    version.add_parser(subparsers, fmt_parent)
 
     args = parser.parse_args()
 

--- a/keepassxc_cli/commands/clip.py
+++ b/keepassxc_cli/commands/clip.py
@@ -12,9 +12,8 @@ from keepassxc_cli.output import ensure_scheme
 logger = logging.getLogger(__name__)
 
 
-def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
-    parents = [fmt_parent] if fmt_parent else []
-    p = subparsers.add_parser("clip", parents=parents, help="Copy a field to clipboard")
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("clip", help="Copy a field to clipboard")
     p.add_argument("url", help="URL to look up")
     p.add_argument(
         "field",

--- a/keepassxc_cli/commands/unlock.py
+++ b/keepassxc_cli/commands/unlock.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import argparse
-import json
-from importlib.metadata import PackageNotFoundError, version
+import logging
 from pathlib import Path
 
 from keepassxc_browser_api import BrowserClient, BrowserConfig
 
 from keepassxc_cli.config import CliConfig
+from keepassxc_cli.output import print_result
+
+logger = logging.getLogger(__name__)
 
 
 def add_parser(subparsers: argparse._SubParsersAction, fmt_parent: argparse.ArgumentParser | None = None) -> None:
     parents = [fmt_parent] if fmt_parent else []
-    p = subparsers.add_parser("version", parents=parents, help="Show the keepassxc-cli version")
+    p = subparsers.add_parser("unlock", parents=parents, help="Unlock the KeePassXC database")
     p.set_defaults(func=run)
 
 
@@ -25,12 +27,6 @@ def run(
     *,
     fmt: str = "table",
 ) -> int:
-    try:
-        ver = version("keepassxc-cli")
-    except PackageNotFoundError:
-        ver = "unknown"
-    if fmt == "json":
-        print(json.dumps({"version": ver}, indent=2))
-    else:
-        print(f"keepassxc-cli {ver}")
+    client.ensure_unlocked()
+    print_result("Database unlocked.", fmt)
     return 0

--- a/tests/manual_test.md
+++ b/tests/manual_test.md
@@ -1,0 +1,233 @@
+
+## Manual Test Plan
+
+These tests require KeePassXC to be running with a database open and browser integration enabled. Run `keepassxc-cli setup` once before starting.
+
+### Prerequisites
+
+```bash
+keepassxc-cli setup          # allow association in the KeePassXC popup
+keepassxc-cli status         # should print "Connected" and association info
+keepassxc-cli status -j      # same, JSON output
+keepassxc-cli version        # prints version, no KeePassXC required
+keepassxc-cli version -j     # {"version": "<semver>"}
+```
+
+---
+
+### `mkdir` — Create groups
+
+```bash
+# Create a top-level group
+keepassxc-cli mkdir "TestGroup"
+# Expected: "Group created." + name/uuid
+
+# Create a nested group (parent must exist)
+keepassxc-cli mkdir "TestGroup/Sub"
+# Expected: "Group created." with path TestGroup/Sub
+
+# JSON output
+keepassxc-cli mkdir "TestGroup/Sub2" -j
+# Expected: {"name": "Sub2", "uuid": "<uuid>"}
+```
+
+---
+
+### `group-uuid` — Look up group UUID
+
+```bash
+keepassxc-cli group-uuid "TestGroup"
+# Expected: prints UUID of TestGroup
+
+keepassxc-cli group-uuid "TestGroup/Sub" -j
+# Expected: {"path": "TestGroup/Sub", "name": "Sub", "uuid": "<uuid>"}
+
+keepassxc-cli group-uuid "DoesNotExist"
+# Expected: non-zero exit code, error message
+```
+
+---
+
+### `add` — Add entries
+
+```bash
+# Minimal: positional url + username, password prompted
+keepassxc-cli add https://test.example.com alice
+# Expected: prompts for password twice, prints "Entry added.", entry visible in KeePassXC
+
+# Password inline
+keepassxc-cli add https://test2.example.com bob --password s3cr3t
+# Expected: "Entry added." without password prompt
+
+# Into a specific group by path
+keepassxc-cli add https://test3.example.com carol --password pass --group "TestGroup"
+# Expected: "Entry added.", entry under TestGroup in KeePassXC
+
+# Into a specific group by UUID (use UUID from group-uuid above)
+keepassxc-cli add https://test4.example.com dave --password pass --group-uuid <uuid-from-group-uuid>
+# Expected: "Entry added.", entry under TestGroup in KeePassXC
+
+# JSON output
+keepassxc-cli add https://test5.example.com eve --password pass -j
+# Expected: {"status": "ok", "message": "Entry added."}
+
+# Bare hostname (no scheme) — should auto-prefix https:// with warning
+keepassxc-cli add noscheme.example.com frank --password pass
+# Expected: warning on stderr "Prefixing https://", "Entry added."
+
+# Duplicate: adding same URL+username again
+keepassxc-cli add https://test.example.com alice --password s3cr3t
+# Expected: create a second entry (KeePassXC allows duplicates)
+```
+
+---
+
+### `show` — Show entries
+
+```bash
+keepassxc-cli show https://test.example.com
+# Expected: table with username, URL; password/TOTP hidden
+
+keepassxc-cli show https://test.example.com -p
+# Expected: same table with password column revealed
+
+keepassxc-cli show https://test.example.com -j
+# Expected: JSON array of entries, password field absent
+
+keepassxc-cli show https://test.example.com -p -j
+# Expected: JSON with password included
+
+keepassxc-cli show https://doesnotexist.example.com
+# Expected: "No entries found" message, exit code 1
+```
+
+---
+
+### `totp` — Get TOTP code
+
+> Requires an entry with TOTP configured in KeePassXC.
+
+```bash
+keepassxc-cli totp https://github.com
+# Expected: 6-digit TOTP code
+
+keepassxc-cli totp https://github.com -j
+# Expected: {"totp": "<code>"}
+
+keepassxc-cli totp https://test.example.com     # entry without TOTP
+# Expected: error or empty, non-zero exit
+```
+
+---
+
+### `clip` — Copy field to clipboard
+
+```bash
+# URL is first positional arg, field is second
+keepassxc-cli clip https://test.example.com password
+# Expected: "Copied password to clipboard.", clipboard contains password
+
+keepassxc-cli clip https://test.example.com username
+# Expected: "Copied username to clipboard."
+
+keepassxc-cli clip https://github.com totp
+# Expected: copies current TOTP code
+
+# Invalid field name
+keepassxc-cli clip https://test.example.com nosuchfield
+# Expected: error, non-zero exit
+```
+
+---
+
+### `edit` — Edit entries
+
+```bash
+# Edit username (URL matches single entry)
+keepassxc-cli edit https://test2.example.com --username newbob
+# Expected: "Entry updated.", verify new username in KeePassXC
+
+# Edit password
+keepassxc-cli edit https://test2.example.com --password newpass
+# Expected: "Entry updated."
+
+# URL matches multiple entries — must provide --uuid
+keepassxc-cli edit https://test.example.com --username updated
+# Expected: error listing multiple matches, prompts for --uuid
+
+keepassxc-cli edit https://test.example.com --uuid <uuid> --username updated
+# Expected: "Entry updated."
+
+# JSON output
+keepassxc-cli edit https://test2.example.com --username finalbob -j
+# Expected: {"status": "ok", "message": "Entry updated."}
+
+# Non-existent URL
+keepassxc-cli edit https://ghost.example.com --username x
+# Expected: error, non-zero exit
+```
+
+---
+
+### `rm` — Delete entries
+
+```bash
+# Single match — prompts for confirmation
+keepassxc-cli rm https://test2.example.com
+# Expected: confirmation prompt; enter 'y' → "Entry deleted."
+
+# Skip confirmation
+keepassxc-cli rm https://test3.example.com --yes
+# Expected: "Entry deleted." without prompt
+
+# JSON output
+keepassxc-cli rm https://test4.example.com --yes -j
+# Expected: {"status": "ok", "message": "Entry deleted."}
+
+# Multiple matches — must provide --uuid
+keepassxc-cli rm https://test.example.com --yes
+# Expected: error table listing all matches, asks to rerun with --uuid
+
+keepassxc-cli rm https://test.example.com --uuid <uuid> --yes
+# Expected: "Entry deleted.", only that entry removed
+
+# Non-existent URL
+keepassxc-cli rm https://gone.example.com --yes
+# Expected: error, non-zero exit
+```
+
+---
+
+### `lock` — Lock the database
+
+```bash
+keepassxc-cli lock
+# Expected: "Database locked.", KeePassXC GUI shows locked state
+
+keepassxc-cli lock -j
+# Expected: {"status": "ok", "message": "Database locked."}
+
+# After locking — subsequent commands should trigger unlock or fail
+keepassxc-cli status
+# Expected: "Database locked" or unlock prompt depending on biometric config
+```
+
+---
+
+### `unlock` — Unlock the database
+
+```bash
+# First lock the database
+keepassxc-cli lock
+
+# Then unlock (triggers TouchID/biometrics if configured)
+keepassxc-cli unlock
+# Expected: "Database unlocked.", KeePassXC GUI shows unlocked state
+
+keepassxc-cli lock && keepassxc-cli unlock -j
+# Expected: {"status": "ok", "message": "Database unlocked."}
+
+# Quit KeePassXC entirely, then:
+keepassxc-cli unlock
+# Expected: error "Cannot connect to KeePassXC", exit code 2
+```

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,7 +11,7 @@ from keepassxc_browser_api import Entry, BrowserConfig, Association
 from keepassxc_browser_api.exceptions import ConnectionError, DatabaseLockedError, ProtocolError
 from keepassxc_cli.config import CliConfig
 from keepassxc_cli.commands import (
-    setup, status, show, add, edit, rm, totp, clip, lock, mkdir, group_uuid, version,
+    setup, status, show, add, edit, rm, totp, clip, lock, unlock, mkdir, group_uuid, version,
 )
 
 
@@ -477,6 +477,43 @@ class TestVersionCommand:
         assert rc == 0
         out = capsys.readouterr().out
         assert "unknown" in out
+
+    def test_json_output(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        import json
+        with patch("keepassxc_cli.commands.version.version", return_value="2.1.0"):
+            args = make_args()
+            rc = version.run(mock_client, args, cli_config, browser_config, browser_config_path, fmt="json")
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["version"] == "2.1.0"
+
+
+# --- unlock ---
+
+
+class TestUnlockCommand:
+    def test_success(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        mock_client.ensure_unlocked.return_value = None
+        args = make_args()
+        rc = unlock.run(mock_client, args, cli_config, browser_config, browser_config_path)
+        assert rc == 0
+        mock_client.ensure_unlocked.assert_called_once()
+        assert "unlocked" in capsys.readouterr().out.lower()
+
+    def test_json_output(self, mock_client, cli_config, browser_config, browser_config_path, capsys):
+        import json
+        mock_client.ensure_unlocked.return_value = None
+        args = make_args()
+        rc = unlock.run(mock_client, args, cli_config, browser_config, browser_config_path, fmt="json")
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "ok"
+
+    def test_database_locked_propagates(self, mock_client, cli_config, browser_config, browser_config_path):
+        mock_client.ensure_unlocked.side_effect = DatabaseLockedError("timed out")
+        args = make_args()
+        with pytest.raises(DatabaseLockedError):
+            unlock.run(mock_client, args, cli_config, browser_config, browser_config_path)
 
 
 # --- exit codes ---


### PR DESCRIPTION
Three small CLI changes:

- **`unlock` command**: new command wrapping `client.ensure_unlocked()`. Triggers biometric (TouchID/fingerprint) unlock. Supports `-j` output.
- **`version -j`**: JSON output `{"version": "..."}` added.
- **`clip` no `-j`**: removed `-j` from clip (clipboard commands have no JSON output).

73 tests passing. README and manual test plan updated.